### PR TITLE
adding a note about prior gtest in system affecting build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ ctest --output-on-failure
 [sudo] make install
 ```
 
+Note: Existing gtest library in the system (especially static gtest libraries built with other compilers) 
+may conflict with the build process; if errors are encountered with already existing gtest library,
+uninstalling or temporarily renaming gtest will force cmake to download and build gtest and solve the problem
+
 Note: To disable inline assembly optimisations in rocRAND (for both the host library and
 the device functions provided in `rocrand_kernel.h`) set cmake option `ENABLE_INLINE_ASM`
 to `OFF`.


### PR DESCRIPTION
Added a note in readme to warn users about existing libgtest.a in the system causing build failure