### PR TITLE
Fix missing gridlaunch.h build issue

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -50,15 +50,21 @@ if(HIP_PLATFORM STREQUAL "nvcc")
     CUDA_ADD_LIBRARY(rocrand ${rocRAND_SRCS})
 else()
     add_library(rocrand ${rocRAND_SRCS})
-    target_link_libraries(rocrand
-        PRIVATE
-            # We keep hip::hip_hcc private, because otherwise it's not possible
-            # to link to roc::rocrand when using different compiler than hcc,
-            # hip::hip_hcc adds hcc-specific compilation flags.
-            hip::hip_hcc
-            hip::hip_device
-            hcc::hccshared
-    )
+
+    # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
+    if(TARGET hip::device)
+      target_link_libraries( rocrand PRIVATE hip::device )
+    else()
+      target_link_libraries( rocrand
+          PRIVATE
+              # We keep hip::hip_hcc private, because otherwise it's not possible
+              # to link to roc::rocrand when using different compiler than hcc,
+              # hip::hip_hcc adds hcc-specific compilation flags.
+              hip::hip_hcc
+              hip::hip_device
+              hcc::hccshared
+      )
+    endif()
     set(rocrand_DEPENDENCIES "hip")
 endif()
 
@@ -161,13 +167,13 @@ if(HIP_PLATFORM STREQUAL "nvcc")
         ${CUDA_curand_LIBRARY}
     )
 else()
-    target_link_libraries(hiprand
-        PRIVATE
-            rocrand
-            hip::hip_hcc
-            hip::hip_device
-            hcc::hccshared
-    )
+    # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
+    if(TARGET hip::device)
+      target_link_libraries( hiprand PRIVATE rocrand hip::device )
+    else()
+      target_link_libraries( hiprand PRIVATE rocrand hip::hip_hcc hip::hip_device hcc::hccshared )
+    endif()
+
     foreach(amdgpu_target ${AMDGPU_TARGETS})
         target_link_libraries(hiprand PRIVATE --amdgpu-target=${amdgpu_target})
     endforeach()


### PR DESCRIPTION
When building with top of 1.8.x branches of HIP and HCC, there is a build issues with missing gridlaunch.h header file. hip::hip_hcc no longer has a dependency on HCC runtime, so we need to use hip::device now.