### PR TITLE
Do not typedef this - it causes errors unless fpermissive is specified.

### DIFF
--- a/library/include/rocrand_sobol32.h
+++ b/library/include/rocrand_sobol32.h
@@ -78,8 +78,6 @@ class sobol32_engine
 {
 public:
 
-    typedef sobol32_state<UseSharedVectors> sobol32_state;
-
     FQUALIFIERS
     sobol32_engine() { }
 
@@ -200,7 +198,7 @@ protected:
 
 protected:
     // State
-    sobol32_state m_state;
+    sobol32_state<UseSharedVectors> m_state;
 
 }; // sobol32_engine class
 


### PR DESCRIPTION
This originates from integrating rocRAND w/ PyTorch. the build process complains that sobol32state is being redefined. Since this seems to be a non-critical typedef, can we remove it?