### PR TITLE
fix for swdev-155298

### DIFF
--- a/test/crush/stat_test_common.hpp
+++ b/test/crush/stat_test_common.hpp
@@ -118,7 +118,7 @@ void analyze(const size_t size,
              const bool save_plots,
              const std::string plot_name,
              const double mean, const double stddev,
-             const distribution_func_type& distribution_func)
+             const distribution_func_type& distribution_func)__attribute__((cpu))
 {
     if (save_plots)
     {


### PR DESCRIPTION
Comment from swdev-155298

FE generates invalid addrspace_cast from constant to generic, which then leads to ill-formed Phi.