### PR TITLE
Enable hip-clang with cmake changes to link -lpthread and -lm

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,10 @@ foreach(test_src ${rocRAND_TEST_SRCS})
         foreach(amdgpu_target ${AMDGPU_TARGETS})
             target_link_libraries(${test_name} --amdgpu-target=${amdgpu_target})
         endforeach()
+        if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+            # hip-clang needs specific flag to turn on pthread and m
+            target_link_libraries(${test_name} -lpthread -lm)
+        endif()
     endif()
     set_target_properties(
         ${test_name}
@@ -122,6 +126,10 @@ foreach(test_src ${hipRAND_TEST_SRCS})
         foreach(amdgpu_target ${AMDGPU_TARGETS})
             target_link_libraries(${test_name} --amdgpu-target=${amdgpu_target})
         endforeach()
+        if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+            # hip-clang needs specific flag to turn on pthread and m
+            target_link_libraries(${test_name} -lpthread -lm)
+        endif()
     endif()
     set_target_properties(${test_name}
         PROPERTIES

--- a/test/linkage/CMakeLists.txt
+++ b/test/linkage/CMakeLists.txt
@@ -50,6 +50,10 @@ function(add_rocrand_link_test TEST_SOURCES)
         foreach(amdgpu_target ${AMDGPU_TARGETS})
             target_link_libraries(${TEST_TARGET} --amdgpu-target=${amdgpu_target})
         endforeach()
+        if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+            # hip-clang needs specific flag to turn on pthread and m
+            target_link_libraries(${TEST_TARGET} -lpthread -lm)
+        endif()
     endif()
     set_target_properties(
         ${TEST_TARGET}
@@ -106,6 +110,10 @@ function(add_hiprand_link_test TEST_SOURCES)
         foreach(amdgpu_target ${AMDGPU_TARGETS})
             target_link_libraries(${TEST_TARGET} --amdgpu-target=${amdgpu_target})
         endforeach()
+        if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+            # hip-clang needs specific flag to turn on pthread and m
+            target_link_libraries(${TEST_TARGET} -lpthread -lm)
+        endif()
     endif()
     set_target_properties(${TEST_TARGET}
         PROPERTIES


### PR DESCRIPTION
This will help fix build issues for tests using hip-clang.