### PR TITLE
unify forceinline/inline handling

### DIFF
--- a/library/include/hiprand_kernel.h
+++ b/library/include/hiprand_kernel.h
@@ -22,11 +22,7 @@
 #define HIPRAND_KERNEL_H_
 
 #ifndef QUALIFIERS
-#ifdef __HIP_PLATFORM_HCC__
-    #define QUALIFIERS inline __forceinline__ __device__
-#else
-    #define QUALIFIERS __forceinline__ __device__
-#endif // __HIP_PLATFORM_HCC__
+#define QUALIFIERS __forceinline__ __device__
 #endif // QUALIFIERS
 
 #include <hip/hip_runtime.h>

--- a/library/include/rocrand_kernel.h
+++ b/library/include/rocrand_kernel.h
@@ -22,11 +22,7 @@
 #define ROCRAND_KERNEL_H_
 
 #ifndef FQUALIFIERS
-#ifdef __HIP_PLATFORM_HCC__
-    #define FQUALIFIERS inline __forceinline__ __device__
-#else
-    #define FQUALIFIERS __forceinline__ __device__
-#endif // __HIP_PLATFORM_HCC__
+#define FQUALIFIERS __forceinline__ __device__
 #endif // FQUALIFIERS
 
 #include "rocrand_common.h"


### PR DESCRIPTION
As of HIP PR #654, `__forceinline__` is defined compatible with CUDA.