### PR TITLE
warning: duplicate 'inline' declaration specifier

### DIFF
--- a/library/include/hiprand_kernel.h
+++ b/library/include/hiprand_kernel.h
@@ -22,11 +22,7 @@
 #define HIPRAND_KERNEL_H_
 
 #ifndef QUALIFIERS
-#ifdef __HIP_PLATFORM_HCC__
-    #define QUALIFIERS inline __forceinline__ __device__
-#else
-    #define QUALIFIERS __forceinline__ __device__
-#endif // __HIP_PLATFORM_HCC__
+#define QUALIFIERS __forceinline__ __device__
 #endif // QUALIFIERS
 
 #include <hip/hip_runtime.h>

--- a/library/include/hiprand_kernel_hcc.h
+++ b/library/include/hiprand_kernel_hcc.h
@@ -25,7 +25,7 @@
 /// @{
 
 #ifndef QUALIFIERS
-#define QUALIFIERS inline __forceinline__ __device__
+#define QUALIFIERS __forceinline__ __device__
 #endif // QUALIFIERS
 
 #include <hip/hip_runtime.h>

--- a/library/include/rocrand_kernel.h
+++ b/library/include/rocrand_kernel.h
@@ -22,11 +22,7 @@
 #define ROCRAND_KERNEL_H_
 
 #ifndef FQUALIFIERS
-#ifdef __HIP_PLATFORM_HCC__
-    #define FQUALIFIERS inline __forceinline__ __device__
-#else
-    #define FQUALIFIERS __forceinline__ __device__
-#endif // __HIP_PLATFORM_HCC__
+#define FQUALIFIERS __forceinline__ __device__
 #endif // FQUALIFIERS
 
 #include "rocrand_common.h"


### PR DESCRIPTION
This PR is equivalent to #34 and addresses the reviewer comment. The original commits are unchanged.

Since hip_hcc is defining `__foreceinline__` [here](https://github.com/ROCm-Developer-Tools/HIP/blob/bd658aa9ea249068eb5034d9a8f157567f57fed8/include/hip/hcc_detail/host_defines.h#L55) which includes the attribute `inline` the additional usage of the inline attribute within rocRAND creates warnings.

warning with `rocm 2.0.89 amd64`
```
/opt/rocm/rocrand/include/rocrand_normal.h:179:1: warning: duplicate 'inline' declaration specifier [-Wduplicate-decl-specifier]
FQUALIFIERS
^
/opt/rocm/hiprand/include/hiprand_kernel_hcc.h:35:21: note: expanded from macro 'FQUALIFIERS'
                    ^
/opt/rocm/hiprand/include/hiprand_kernel.h:26:31: note: expanded from macro 'QUALIFIERS'
    #define QUALIFIERS inline __forceinline__ __device__
                              ^
/opt/rocm/hip/include/hip/hcc_detail/host_defines.h:55:25: note: expanded from macro '__forceinline__'
```