### PR TITLE
Simplify convoluted vector indexing

### DIFF
--- a/library/include/rocrand_philox4x32_10.h
+++ b/library/include/rocrand_philox4x32_10.h
@@ -195,22 +195,7 @@ public:
     FQUALIFIERS
     unsigned int next()
     {
-        unsigned int ret;
-        switch(m_state.substate)
-        {
-            case 0:
-                ret = m_state.result.x;
-                break;
-            case 1:
-                ret = m_state.result.y;
-                break;
-            case 2:
-                ret = m_state.result.z;
-                break;
-            default:
-                ret = m_state.result.w;
-                break;
-        }
+        unsigned int ret = m_state.result.data[m_state.substate];
         m_state.substate++;
         if(m_state.substate == 4)
         {

--- a/library/include/rocrand_philox4x32_10.h
+++ b/library/include/rocrand_philox4x32_10.h
@@ -195,7 +195,7 @@ public:
     FQUALIFIERS
     unsigned int next()
     {
-        #if defined(__HIPCC_PLATFORM_HCC__)
+        #if defined(__HIP_PLATFORM_HCC__)
             unsigned int ret = m_state.result.data[m_state.substate];
         #else
             unsigned int ret = (&m_state.result.x)[m_state.substate];

--- a/library/include/rocrand_philox4x32_10.h
+++ b/library/include/rocrand_philox4x32_10.h
@@ -195,7 +195,11 @@ public:
     FQUALIFIERS
     unsigned int next()
     {
-        unsigned int ret = m_state.result.data[m_state.substate];
+        #if defined(HIPCC_PLATFORM_HCC)
+            unsigned int ret = m_state.result.data[m_state.substate];
+        #else
+            unsigned int ret = (&m_state.result.x)[m_state.substate];
+        #endif
         m_state.substate++;
         if(m_state.substate == 4)
         {

--- a/library/include/rocrand_philox4x32_10.h
+++ b/library/include/rocrand_philox4x32_10.h
@@ -195,7 +195,7 @@ public:
     FQUALIFIERS
     unsigned int next()
     {
-        #if defined(HIPCC_PLATFORM_HCC)
+        #if defined(__HIPCC_PLATFORM_HCC__)
             unsigned int ret = m_state.result.data[m_state.substate];
         #else
             unsigned int ret = (&m_state.result.x)[m_state.substate];


### PR DESCRIPTION
Clang native vector types support indexing, and HIP vector types expose a `::data` member which represents the underlying native vector, so we might as well use it.