### PR TITLE
Fix the rocrand header path

### DIFF
--- a/library/include/hiprand_hcc.h
+++ b/library/include/hiprand_hcc.h
@@ -21,7 +21,7 @@
 #ifndef HIPRAND_HCC_H_
 #define HIPRAND_HCC_H_
 
-#include <rocrand.h>
+#include <rocrand/rocrand.h>
 
 typedef rocrand_generator_base_type hiprandGenerator_st;
 

--- a/library/include/hiprand_kernel_hcc.h
+++ b/library/include/hiprand_kernel_hcc.h
@@ -34,7 +34,7 @@
 /// \cond
 #define FQUALIFIERS QUALIFIERS
 /// \endcond
-#include <rocrand_kernel.h>
+#include <rocrand/rocrand_kernel.h>
 
 /// \cond
 #define DEFINE_HIPRAND_STATE(hiprand_name, rocrand_name) \


### PR DESCRIPTION
After install the debian package, rocrand header files
locate rocrand folders rather than the root of include.