### PR TITLE
Fixing pip version error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ variables:
   image: rocm/rocm-terminal:latest
   before_script:
     - $SUDO_CMD apt-get update -qq
-    - $SUDO_CMD apt-get install -y -qq ca-certificates git wget tar xz-utils bzip2 build-essential pkg-config g++ gfortran
+    - $SUDO_CMD apt-get install -y -qq ca-certificates git wget tar xz-utils bzip2 build-essential pkg-config g++ gfortran findutils
     - hipconfig
     # cmake
     - mkdir -p $DEPS_DIR/cmake
@@ -57,7 +57,7 @@ build:rocm:
   script:
     - mkdir build
     - cd build
-    - CXX=hcc cmake -DBUILD_BENCHMARK=ON -DBUILD_FORTRAN_WRAPPER=ON -DBUILD_CRUSH_TEST=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../.
+    - CXX=hcc cmake -DBUILD_BENCHMARK=ON -DBUILD_FORTRAN_WRAPPER=ON -DBUILD_CRUSH_TEST=ON -DBUILD_TOOLS=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../.
     - make -j16
     - make package
   artifacts:
@@ -127,26 +127,37 @@ test:rocm_python:
     - $SUDO_CMD apt-get update -qq
     - $SUDO_CMD apt-get install -y -qq python python-pip python-numpy
     - $SUDO_CMD apt-get install -y -qq python3 python3-pip python3-numpy
+    - $SUDO_CMD apt-get install -y -qq wget
+    - sudo apt-get -y remove python-pip python3-pip
+    - wget https://bootstrap.pypa.io/get-pip.py
+    - sudo -H python get-pip.py
+    - sudo -H python3 get-pip.py
+
   script:
     - export ROCRAND_PATH=$CI_PROJECT_DIR/build/library/
-    # rocRAND Wrapper
+    # rocRAND Wrapper with Python 2
     - cd $CI_PROJECT_DIR/python/rocrand
-    - $SUDO_CMD python setup.py test
+    - $SUDO_CMD python2 setup.py test
+    - pip2 install . --user
+    - $SUDO_CMD python2 tests/rocrand_test.py
+    - pip2 uninstall --yes rocrand
+    # hipRAND Wrapper with Python 2
+    - cd $CI_PROJECT_DIR/python/hiprand
+    - $SUDO_CMD python2 setup.py test
+    - pip2 install . --user
+    - $SUDO_CMD python2 tests/hiprand_test.py
+    - pip2 uninstall --yes hiprand
+    # rocRAND Wrapper with Python 3
+    - pip3 --version
+    - cd $CI_PROJECT_DIR/python/rocrand
     - $SUDO_CMD python3 setup.py test
-    - pip install .
-    - $SUDO_CMD python tests/rocrand_test.py
-    - pip uninstall --yes rocrand
-    - pip3 install .
+    - pip3 install . --user
     - $SUDO_CMD python3 tests/rocrand_test.py
     - pip3 uninstall --yes rocrand
-    # hipRAND Wrapper
+    # hipRAND Wrapper with Python 3
     - cd $CI_PROJECT_DIR/python/hiprand
-    - $SUDO_CMD python setup.py test
     - $SUDO_CMD python3 setup.py test
-    - pip install .
-    - $SUDO_CMD python tests/hiprand_test.py
-    - pip uninstall --yes hiprand
-    - pip3 install .
+    - pip3 install . --user
     - $SUDO_CMD python3 tests/hiprand_test.py
     - pip3 uninstall --yes hiprand
 
@@ -158,6 +169,7 @@ test:rocm_package:
   script:
     - cd build
     - $SUDO_CMD dpkg -i rocrand-*.deb
+    - find -L /opt/rocm/ | grep rand | sort
     - mkdir ../build_package_test && cd ../build_package_test
     - cmake ../test/package/.
     - make VERBOSE=1
@@ -165,20 +177,22 @@ test:rocm_package:
     - ldd ./test_hiprand
     - $SUDO_CMD dpkg -r rocrand
 
-# test:rocm_install:
-#   extends: .rocm
-#   stage: test
-#   script:
-#     - mkdir build_only_install
-#     - cd build_only_install
-#     - CXX=hcc cmake -DBUILD_TEST=OFF ../.
-#     - make -j16
-#     - $SUDO_CMD make install
-#     - mkdir ../install_test && cd ../install_test
-#     - cmake ../test/package/.
-#     - make VERBOSE=1
-#     - $SUDO_CMD ctest --output-on-failure
-#     - ldd ./test_hiprand
+test:rocm_install:
+  extends: .rocm
+  stage: test
+  dependencies: []
+  script:
+    - mkdir build_only_install
+    - cd build_only_install
+    - CXX=hcc cmake -DBUILD_TEST=OFF -DBUILD_FORTRAN_WRAPPER=ON ../.
+    - make -j16
+    - $SUDO_CMD make install
+    - find -L /opt/rocm/ | grep rand | sort
+    - mkdir ../install_test && cd ../install_test
+    - cmake ../test/package/.
+    - make VERBOSE=1
+    - $SUDO_CMD ctest --output-on-failure
+    - ldd ./test_hiprand
 
 
 # NVCC
@@ -191,7 +205,7 @@ test:rocm_package:
     - nvidia-smi
     # HIP-nvcc
     - $SUDO_CMD apt-get update -qq
-    - $SUDO_CMD apt-get install -y -qq ca-certificates git wget tar xz-utils bzip2 build-essential pkg-config g++ gfortran
+    - $SUDO_CMD apt-get install -y -qq ca-certificates git wget tar xz-utils bzip2 build-essential pkg-config g++ gfortran findutils
     - wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | $SUDO_CMD apt-key add -
     - echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | $SUDO_CMD tee /etc/apt/sources.list.d/rocm.list
     - $SUDO_CMD apt-get update -qq
@@ -216,7 +230,7 @@ build:nvcc:
   script:
     - mkdir build
     - cd build
-    - cmake -DBUILD_BENCHMARK=ON -DBUILD_FORTRAN_WRAPPER=ON -DBUILD_CRUSH_TEST=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../.
+    - cmake -DBUILD_BENCHMARK=ON -DBUILD_FORTRAN_WRAPPER=ON -DBUILD_CRUSH_TEST=ON -DBUILD_TOOLS=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../.
     - make -j16
     - make package
   artifacts:
@@ -305,6 +319,7 @@ test:nvcc_package:
   script:
     - cd build
     - $SUDO_CMD dpkg -i rocrand-*.deb
+    - find -L /opt/rocm/ | grep rand | sort
     - mkdir ../build_package_test && cd ../build_package_test
     - cmake ../test/package/.
     - make VERBOSE=1
@@ -312,17 +327,20 @@ test:nvcc_package:
     - ldd ./test_hiprand
     - $SUDO_CMD dpkg -r rocrand
 
-# test:nvcc_install:
-#   extends: .nvcc
-#   stage: test
-#   script:
-#     - mkdir build_only_install
-#     - cd build_only_install
-#     - cmake -DBUILD_TEST=OFF ../.
-#     - make -j16
-#     - $SUDO_CMD make install
-#     - mkdir ../install_test && cd ../install_test
-#     - cmake ../test/package/.
-#     - make VERBOSE=1
-#     - $SUDO_CMD ctest --output-on-failure
-#     - ldd ./test_hiprand
+test:nvcc_install:
+  extends: .nvcc
+  stage: test
+  dependencies: []
+  script:
+    - mkdir build_only_install
+    - cd build_only_install
+    - cmake -DBUILD_TEST=OFF -DBUILD_FORTRAN_WRAPPER=ON ../.
+    - make -j16
+    - $SUDO_CMD make install
+    - find -L /opt/rocm/ | grep rand | sort
+    - mkdir ../install_test && cd ../install_test
+    - cmake ../test/package/.
+    - make VERBOSE=1
+    - $SUDO_CMD ctest --output-on-failure
+    - ldd ./test_hiprand
+


### PR DESCRIPTION
Error was:
```
File "/tmp/pip-build-lNW8PJ/numpy/setup.py", line 31, in <module>
        raise RuntimeError("Python version >= 3.5 required.")
    RuntimeError: Python version >= 3.5 required.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-lNW8PJ/numpy/
You are using pip version 8.1.1, however version 19.2.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
ERROR: Job failed: exit code 1
```
This fixes it