### PR TITLE
rocRAND changes to support multiple ROCM installation

### DIFF
--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -1,4 +1,6 @@
 #
+set(ROCM_DISABLE_LDCONFIG OFF CACHE BOOL "")
+
 function(package_set_postinst_prerm LIB_NAMES LIB_DIRS INCLUDE_DIRS)
     list(LENGTH LIB_NAMES len1)
     list(LENGTH LIB_DIRS  len2)
@@ -18,7 +20,9 @@ function(package_set_postinst_prerm LIB_NAMES LIB_DIRS INCLUDE_DIRS)
 
         set(POSTINST_SOURCE "${POSTINST_SOURCE}\nmkdir -p ${inc_dir}/../../include/")
         set(POSTINST_SOURCE "${POSTINST_SOURCE}\nmkdir -p ${lib_dir}/../../lib/cmake/${lib_name}")
-        set(POSTINST_SOURCE "${POSTINST_SOURCE}\necho \"${lib_dir}\" > /etc/ld.so.conf.d/${lib_name}.conf")
+        if(NOT ${ROCM_DISABLE_LDCONFIG})
+            set(POSTINST_SOURCE "${POSTINST_SOURCE}\necho \"${lib_dir}\" > /etc/ld.so.conf.d/${lib_name}.conf")
+        endif()
         set(POSTINST_SOURCE "${POSTINST_SOURCE}\nln -sr ${inc_dir} ${inc_dir}/../../include/${lib_name}")
         set(POSTINST_SOURCE "${POSTINST_SOURCE}\nln -sr ${lib_dir}/lib${lib_name}.so ${lib_dir}/../../lib/lib${lib_name}.so")
         set(POSTINST_SOURCE "${POSTINST_SOURCE}\nln -sr ${lib_dir}/cmake/${lib_name} ${lib_dir}/../../lib/cmake/${lib_name}\n")

--- a/install
+++ b/install
@@ -11,6 +11,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-i|--install] install after build"
     echo "    [-p|--package] build package"
+    echo "    [-r]--relocatable] create a package to support relocatable ROCm"
     #Not implemented yet
     #    echo "    [-d|--dependencies] install build dependencies"
     echo "    [-c|--clients] build library clients too (combines with -i & -d)"
@@ -28,7 +29,9 @@ build_clients=false
 build_release=true
 run_tests=false
 build_hip_clang=false
-rocm_path=/opt/rocm/bin
+rocm_path=/opt/rocm
+build_relocatable=false
+
 # #################################################
 # Parameter parsing
 # #################################################
@@ -36,7 +39,7 @@ rocm_path=/opt/rocm/bin
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,package --options hicdtp -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,package,relocatable --options hicdtpr -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -62,6 +65,9 @@ while true; do
 	-p|--package)
 	    build_package=true
 	    shift ;;
+        -r|--relocatable)
+            build_relocatable=true
+            shift ;;
 	-c|--clients)
 	    build_clients=true
 	    shift ;;
@@ -81,6 +87,16 @@ while true; do
     esac
     done
 
+if [[ "${build_relocatable}" == true ]]; then
+    if ! [ -z ${ROCM_PATH+x} ]; then
+        rocm_path=${ROCM_PATH}
+    fi
+
+    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
+    if ! [ -z ${ROCM_RPATH+x} ]; then
+        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
+    fi
+fi
 
 # Instal the pre-commit hook
 #bash .githooks/install
@@ -111,19 +127,22 @@ if ($build_hip_clang); then
 fi
 
 if [ -e /etc/redhat-release ] ; then
-    distro='centos'
+    cmake_executable="cmake3"
 else
-    distro='ubuntu'
+    cmake_executable="cmake"
 fi
 
-case "$distro" in
-    centos)
-        CXX=$rocm_path/$compiler cmake3 -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
-    ;;
-    ubuntu)
-        CXX=$rocm_path/$compiler cmake -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
-    ;;
-esac
+if [[ "${build_relocatable}" == true ]]; then
+    CXX=${rocm_path}/bin/$compiler ${cmake_executable}  -DCMAKE_INSTALL_PREFIX=${rocm_path} \
+    -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DBUILD_CRUSH_TEST=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON \
+    -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
+    -DCMAKE_SHARED_LINKER_FLAGS=${rocm_rpath} \
+    -DROCM_DISABLE_LDCONFIG=ON \
+    -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" \
+    ../../. # or cmake-gui ../.
+else
+    CXX=${rocm_path}/bin/$compiler ${cmake_executable}  -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
+fi
 
 # Build
 make -j$(nproc)


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
  for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
  CMAKE_INSTALL_PREFIX
  CMAKE_PREFIX_PATH
  CMAKE_SHARED_LINKER_FLAGS
  CMAKE_MODULE_PATH
  ROCM_DISABLE_LDCONFIG

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>