### PR TITLE
CMake changes for hipclang. Removing legacy hcc linktarget and find_p…

### DIFF
--- a/cmake/VerifyCompiler.cmake
+++ b/cmake/VerifyCompiler.cmake
@@ -38,7 +38,6 @@ elseif(HIP_PLATFORM STREQUAL "hcc")
         list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip)
         # Ignore hcc warning: argument unused during compilation: '-isystem /opt/rocm/hip/include'
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
-        find_package(hcc REQUIRED CONFIG PATHS /opt/rocm)
         find_package(hip REQUIRED CONFIG PATHS /opt/rocm)
     endif()
 else()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -65,7 +65,7 @@ else()
               # to link to roc::rocrand when using different compiler than hcc,
               # hip::device adds hcc-specific compilation flags.
               hip::device
-              hcc::hccshared
+             # hcc::hccshared
       )
     endif()
     set(rocrand_DEPENDENCIES "hip")
@@ -175,7 +175,7 @@ else()
     if(CXX_VERSION_STRING MATCHES "clang")
       target_link_libraries(hiprand PRIVATE rocrand hip::device)
     else()
-      target_link_libraries(hiprand PRIVATE rocrand hip::device hcc::hccshared)
+      target_link_libraries(hiprand PRIVATE rocrand hip::device)
     endif()
     foreach(amdgpu_target ${AMDGPU_TARGETS})
         target_link_libraries(hiprand PRIVATE --amdgpu-target=${amdgpu_target})


### PR DESCRIPTION
…ackage