### PR TITLE
Hip compiler for nvcc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   # Local build options
   LOCAL_CXXFLAGS: ""
   LOCAL_CMAKE_OPTIONS: ""
-  ROCM_LATEST_PATH: "/opt/rocm-3.5.1/"
+  ROCM_LATEST_PATH: "/opt/rocm-3.5.0/"
 
 # ROCm
 
@@ -43,7 +43,7 @@ variables:
   image: rocm/rocm-terminal:latest
   before_script:
     - $SUDO_CMD apt-get update -qq
-    - $SUDO_CMD apt-get install -y -qq git wget tar xz-utils bzip2 build-essential pkg-config ca-certificates kmod gfortran findutils
+    - $SUDO_CMD apt-get install -y -qq libidn11 git wget tar xz-utils bzip2 build-essential pkg-config ca-certificates kmod gfortran findutils
     - hipconfig
     # cmake
     - mkdir -p $DEPS_DIR/cmake
@@ -108,6 +108,8 @@ include: '.gitlab-ci-gputest.yml'
 test:rocm_python:
   extends: .rocm
   stage: test
+  tags:
+    - rocm-stable
   dependencies:
     - build:rocm
   before_script:
@@ -151,6 +153,8 @@ test:rocm_python:
 test:rocm_package:
   extends: .rocm
   stage: test
+  tags:
+    - rocm-stable
   dependencies:
     - build:rocm
   script:
@@ -158,7 +162,7 @@ test:rocm_package:
     - $SUDO_CMD dpkg -i rocrand-*.deb
     - find -L $ROCM_PATH | grep rand | sort
     - mkdir ../build_package_test && cd ../build_package_test
-    - CXX=hipcc cmake -DHIP_COMPILER=clang ../test/package/.
+    - CXX=hipcc cmake ../test/package/.
     - make VERBOSE=1
     - $SUDO_CMD ctest --output-on-failure
     - ldd ./test_hiprand
@@ -167,11 +171,13 @@ test:rocm_package:
 test:rocm_install:
   extends: .rocm
   stage: test
+  tags:
+    - rocm-stable
   dependencies: []
   script:
     - mkdir build_only_install
     - cd build_only_install
-    - CXX=hipcc cmake -DHIP_COMPILER=clang -DBUILD_TEST=OFF -DBUILD_FORTRAN_WRAPPER=OFF ../.
+    - CXX=hipcc cmake -DBUILD_TEST=OFF -DBUILD_FORTRAN_WRAPPER=OFF ../.
     - make -j16
     - $SUDO_CMD make install
     - find -L $ROCM_PATH | grep rand | sort
@@ -218,7 +224,7 @@ build:nvcc:
   script:
     - mkdir build
     - cd build
-    - cmake -DHIP_COMPILER=nvcc -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DBUILD_FORTRAN_WRAPPER=ON -DBUILD_CRUSH_TEST=ON -DBUILD_TOOLS=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../.
+    - cmake -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DBUILD_FORTRAN_WRAPPER=ON -DBUILD_CRUSH_TEST=ON -DBUILD_TOOLS=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../.
     - make -j16
     - make package
   artifacts:
@@ -318,7 +324,7 @@ test:nvcc_package:
     - $SUDO_CMD dpkg -i rocrand-*.deb
     - find -L $ROCM_PATH | grep rand | sort
     - mkdir ../build_package_test && cd ../build_package_test
-    - cmake -DHIP_COMPILER=nvcc ../test/package/.
+    - cmake ../test/package/.
     - make VERBOSE=1
     - $SUDO_CMD ctest --output-on-failure
     - ldd ./test_hiprand
@@ -331,12 +337,12 @@ test:nvcc_install:
   script:
     - mkdir build_only_install
     - cd build_only_install
-    - cmake -DHIP_COMPILER=nvcc -DBUILD_TEST=OFF -DBUILD_FORTRAN_WRAPPER=ON ../.
+    - cmake -DBUILD_TEST=OFF -DBUILD_FORTRAN_WRAPPER=ON ../.
     - make -j16
     - $SUDO_CMD make install
     - find -L $ROCM_PATH | grep rand | sort
     - mkdir ../install_test && cd ../install_test
-    - cmake -DHIP_COMPILER=nvcc ../test/package/.
+    - cmake ../test/package/.
     - make VERBOSE=1
     - $SUDO_CMD ctest --output-on-failure
     - ldd ./test_hiprand

--- a/cmake/VerifyCompiler.cmake
+++ b/cmake/VerifyCompiler.cmake
@@ -21,8 +21,15 @@
 # SOFTWARE.
 
 list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/hip)
-if(HIP_COMPILER STREQUAL "nvcc")
-  find_package(HIP REQUIRED)
+if(CMAKE_CXX_COMPILER MATCHES ".*/nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    find_package(hip QUIET CONFIG PATHS /opt/rocm)
+    if(NOT hip_FOUND)
+        find_package(HIP REQUIRED)
+        if((HIP_COMPILER STREQUAL "hcc") AND (HIP_PLATFORM STREQUAL "nvcc"))
+           # TODO: The HIP package on NVIDIA platform is incorrect at few versions
+           set(HIP_COMPILER "nvcc" CACHE STRING "HIP Compiler" FORCE)
+        endif()
+    endif()
 else()
   find_package(hip REQUIRED CONFIG PATHS /opt/rocm)
 endif()

--- a/test/package/CMakeLists.txt
+++ b/test/package/CMakeLists.txt
@@ -10,8 +10,15 @@ list(APPEND CMAKE_MODULE_PATH
 )
 
 # Find HIP
-if(HIP_COMPILER STREQUAL "nvcc")
-  find_package(HIP REQUIRED)
+if(CMAKE_CXX_COMPILER MATCHES ".*/nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    find_package(hip QUIET CONFIG PATHS /opt/rocm)
+    if(NOT hip_FOUND)
+        find_package(HIP REQUIRED)
+        if((HIP_COMPILER STREQUAL "hcc") AND (HIP_PLATFORM STREQUAL "nvcc"))
+           # TODO: The HIP package on NVIDIA platform is incorrect at few versions
+           set(HIP_COMPILER "nvcc" CACHE STRING "HIP Compiler" FORCE)
+        endif()
+    endif()
 else()
   find_package(hip REQUIRED CONFIG PATHS /opt/rocm)
 endif()


### PR DESCRIPTION
Set the hip compiler to nvcc, at incorrect case.

Important part:
```
if((HIP_COMPILER STREQUAL "hcc") AND (HIP_PLATFORM STREQUAL "nvcc"))
    # TODO: The HIP package on NVIDIA platform is incorrect at few versions
    set(HIP_COMPILER "nvcc" CACHE STRING "HIP Compiler" FORCE)
endif()
```