### PR TITLE
Updates to the package name to support ROCm upgrade

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -287,6 +287,16 @@ endif()
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 
+# Below block of code is to support older version of rocm-cmake
+# it checks for occurance of '-' in TWEAK and returns the substring after the last '-'
+string(FIND ${rocRAND_VERSION_TWEAK} "-" DASH_POS REVERSE)
+set(MINUS_ONE -1)
+if (NOT DASH_POS EQUAL MINUS_ONE)
+  math(EXPR DASH_POS "${DASH_POS}+1")
+  string(SUBSTRING ${PROJECT_VERSION_TWEAK} ${DASH_POS} 7 PARSED_GIT_TAG)
+  set(rocRAND_VERSION_TWEAK ${PARSED_GIT_TAG})
+endif()
+
 set(DEBIAN_VERSION ${rocRAND_VERSION_TWEAK})
 if(DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
   set(DEBIAN_VERSION $ENV{CPACK_DEBIAN_PACKAGE_RELEASE})

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -275,30 +275,38 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The rocRAND library provides functions th
 set(CPACK_SET_DESTDIR ON)
 set(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
 set(CPACK_RPM_PACKAGE_AUTOREQPROV OFF CACHE BOOL "")
-set(CPACK_PACKAGE_VERSION ${rocRAND_VERSION})
+set(CPACK_PACKAGE_VERSION ${rocRAND_VERSION_MAJOR}.${rocRAND_VERSION_MINOR}.${rocRAND_VERSION_PATCH})
 set(CPACK_PACKAGE_VERSION_MAJOR ${rocRAND_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${rocRAND_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${rocRAND_VERSION_PATCH})
 
-# This section copied from rocm-cmake project per terms of the MIT license
-# rocRAND packaging will switch to use rocm-cmake macros in the future
-if (EXISTS "/etc/os-release")
-  rocm_set_os_id(_os_id)
-  rocm_read_os_release(_version_id "VERSION_ID")
-
-  #only set CPACK_SYSTEM_NAME for AMD supported OSes
-  if (_os_id_centos OR _os_is_rhel)
-    STRING(CONCAT _SYSTEM_NAME "el" ${_version_id} ".x86_64")
-    #Debs use underscrore between OS and architecture
-  elseif(_os_id_ubuntu)
-    STRING(CONCAT _SYSTEM_NAME ${_os_id} "-" ${_version_id} "_amd64")
-  else()
-    #For SLES and unsupported OSes
-    STRING(CONCAT _SYSTEM_NAME ${_os_id} "-" ${_version_id} ".amd64")
-  endif()
-
-  set(CPACK_SYSTEM_NAME ${_SYSTEM_NAME} CACHE STRING "CPACK_SYSTEM_NAME for packaging")
+if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
+  set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}.$ENV{ROCM_LIBPATCH_VERSION}")
 endif()
+
+set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
+
+set(DEBIAN_VERSION ${rocRAND_VERSION_TWEAK})
+if(DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
+  set(DEBIAN_VERSION $ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
+endif()
+
+set(RPM_RELEASE ${rocRAND_VERSION_TWEAK})
+if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
+  set(RPM_RELEASE $ENV{CPACK_RPM_PACKAGE_RELEASE})
+endif()
+
+# '%{?dist}' breaks manual builds on debian systems due to empty Provides
+execute_process(COMMAND rpm --eval %{?dist}
+                RESULT_VARIABLE PROC_RESULT
+                OUTPUT_VARIABLE EVAL_RESULT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (PROC_RESULT EQUAL "0" AND NOT EVAL_RESULT STREQUAL "")
+  string (APPEND RPM_RELEASE "%{?dist}")
+endif()
+set(CPACK_DEBIAN_PACKAGE_RELEASE ${DEBIAN_VERSION})
+set(CPACK_RPM_PACKAGE_RELEASE ${RPM_RELEASE})
 
 package_set_postinst_prerm(
     "hiprand;rocrand"


### PR DESCRIPTION
- Git commit number is removed
- ROCM_VERSION number will be appended to component version as ...<rocm_version_number>
  only when defined in the ENV.
- CPACK_DEBIAN_PACKAGE_RELEASE and CPACK_RPM_PACKAGE_RELEASE are set to git hash,
  if not defined in the ENV which will be defined in the CI environment to provide all the build info.