### PR TITLE
Add Jenkins docs build

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -1,0 +1,69 @@
+#!/usr/bin/env groovy
+// This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
+@Library('rocJenkins@pong') _
+
+// This is file for internal AMD use.
+// If you are interested in running your own Jenkins, please raise a github issue for assistance.
+
+import com.amd.project.*
+import com.amd.docker.*
+import java.nio.file.Path
+
+def runCompileCommand(platform, project, jobName, boolean debug=false)
+{
+    project.paths.construct_build_prefix()
+
+    def command = """#!/usr/bin/env bash
+            set -ex
+            make -C ${project.paths.project_build_prefix}/python/rocrand/docs html
+            make -C ${project.paths.project_build_prefix}/python/hiprand/docs html
+            """
+
+    try
+    {
+        platform.runCommand(this, command)
+    }
+    catch(e)
+    {
+        throw e
+    }
+
+    publishHTML([allowMissing: false,
+                alwaysLinkToLastBuild: false,
+                keepAll: false,
+                reportDir: "${project.paths.project_build_prefix}/python/rocrand/docs/build/html",
+                reportFiles: "index.html",
+                reportName: "Documentation",
+                reportTitles: "Documentation"])
+}
+
+def runCI =
+{
+    nodeDetails, jobName->
+
+    def prj  = new rocProject('rocRAND', 'StaticAnalysis')
+
+    // Define test architectures, optional rocm version argument is available
+    def nodes = new dockerNodes(nodeDetails, jobName, prj)
+
+    boolean formatCheck = false
+    boolean staticAnalysis = true
+
+    def compileCommand =
+    {
+        platform, project->
+
+        runCompileCommand(platform, project, jobName, false)
+    }
+
+    buildProject(prj , formatCheck, nodes.dockerArray, compileCommand, null, null, staticAnalysis)
+}
+
+ci: {
+    String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
+
+    properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * 6')])]))
+    stage(urlJobName) {
+        runCI([ubuntu18:['cpu']], urlJobName)
+    }
+}

--- a/python/hiprand/docs/Makefile
+++ b/python/hiprand/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = hipRANDPythonWrapper
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/python/rocrand/docs/Makefile
+++ b/python/rocrand/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = rocRANDPythonWrapper
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
This adds a Jenkins build for the docs. I'm not entirely sure the best way to handle having both the rocrand and hiprand docs in the same repository, but both are getting built and tested even if only one is actually viewable on the Jenkins page.