### PR TITLE
Workaround performance fix for xorwow

### DIFF
--- a/library/include/rocrand_xorwow.h
+++ b/library/include/rocrand_xorwow.h
@@ -78,9 +78,6 @@ class xorwow_engine
 public:
     struct xorwow_state
     {
-        // Xorshift values (160 bits)
-        unsigned int x[5];
-
         // Weyl sequence value
         unsigned int d;
 
@@ -95,6 +92,9 @@ public:
         float boxmuller_float; // normally distributed float
         double boxmuller_double; // normally distributed double
         #endif
+
+        // Xorshift values (160 bits)
+        unsigned int x[5];
 
         FQUALIFIERS
         ~xorwow_state() { }


### PR DESCRIPTION
The workaround restores lost performance for xorwow engine in newer ROCm builds.  This affected both MI50/Vega20 and MI100.

I'll file an internal ticket with the HIP compiler team shortly about these regressions.