### PR TITLE
Fix memory leaks in rocRAND

### DIFF
--- a/library/include/hiprand.hpp
+++ b/library/include/hiprand.hpp
@@ -933,11 +933,19 @@ public:
         hiprandStatus_t status;
         status = hiprandCreateGenerator(&m_generator, this->type());
         if(status != HIPRAND_STATUS_SUCCESS) throw hiprand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->seed(seed_value);
         }
-        this->seed(seed_value);
+        catch(...)
+        {
+            (void)hiprandDestroyGenerator(m_generator);
+            throw;
+        }
     }
 
     /// \brief Constructs the pseudo-random number engine.
@@ -1097,11 +1105,19 @@ public:
         hiprandStatus_t status;
         status = hiprandCreateGenerator(&m_generator, this->type());
         if(status != HIPRAND_STATUS_SUCCESS) throw hiprand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->seed(seed_value);
         }
-        this->seed(seed_value);
+        catch(...)
+        {
+            (void)hiprandDestroyGenerator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(hiprandGenerator_t&)
@@ -1221,11 +1237,19 @@ public:
         hiprandStatus_t status;
         status = hiprandCreateGenerator(&m_generator, this->type());
         if(status != HIPRAND_STATUS_SUCCESS) throw hiprand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->seed(seed_value);
         }
-        this->seed(seed_value);
+        catch(...)
+        {
+            (void)hiprandDestroyGenerator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(hiprandGenerator_t&)
@@ -1355,7 +1379,15 @@ public:
         hiprandStatus_t status;
         status = hiprandCreateGenerator(&m_generator, this->type());
         if(status != HIPRAND_STATUS_SUCCESS) throw hiprand_cpp::error(status);
-        this->seed(seed_value);
+        try
+        {
+            this->seed(seed_value);
+        }
+        catch(...)
+        {
+            (void)hiprandDestroyGenerator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(hiprandGenerator_t&)
@@ -1477,11 +1509,19 @@ public:
         hiprandStatus_t status;
         status = hiprandCreateGenerator(&m_generator, this->type());
         if(status != HIPRAND_STATUS_SUCCESS) throw hiprand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->dimensions(num_of_dimensions);
         }
-        this->dimensions(num_of_dimensions);
+        catch(...)
+        {
+            (void)hiprandDestroyGenerator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(hiprandGenerator_t&)

--- a/library/include/rocrand.hpp
+++ b/library/include/rocrand.hpp
@@ -925,11 +925,19 @@ public:
         rocrand_status status;
         status = rocrand_create_generator(&m_generator, this->type());
         if(status != ROCRAND_STATUS_SUCCESS) throw rocrand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->seed(seed_value);
         }
-        this->seed(seed_value);
+        catch(...)
+        {
+            (void)rocrand_destroy_generator(m_generator);
+            throw;
+        }
     }
 
     /// \brief Constructs the pseudo-random number engine.
@@ -1089,11 +1097,19 @@ public:
         rocrand_status status;
         status = rocrand_create_generator(&m_generator, this->type());
         if(status != ROCRAND_STATUS_SUCCESS) throw rocrand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->seed(seed_value);
         }
-        this->seed(seed_value);
+        catch(...)
+        {
+            (void)rocrand_destroy_generator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
@@ -1213,11 +1229,19 @@ public:
         rocrand_status status;
         status = rocrand_create_generator(&m_generator, this->type());
         if(status != ROCRAND_STATUS_SUCCESS) throw rocrand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->seed(seed_value);
         }
-        this->seed(seed_value);
+        catch(...)
+        {
+            (void)rocrand_destroy_generator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
@@ -1347,7 +1371,15 @@ public:
         rocrand_status status;
         status = rocrand_create_generator(&m_generator, this->type());
         if(status != ROCRAND_STATUS_SUCCESS) throw rocrand_cpp::error(status);
-        this->seed(seed_value);
+        try
+        {
+            this->seed(seed_value);
+        }
+        catch(...)
+        {
+            (void)rocrand_destroy_generator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
@@ -1469,11 +1501,19 @@ public:
         rocrand_status status;
         status = rocrand_create_generator(&m_generator, this->type());
         if(status != ROCRAND_STATUS_SUCCESS) throw rocrand_cpp::error(status);
-        if(offset_value > 0)
+        try
         {
-            this->offset(offset_value);
+            if(offset_value > 0)
+            {
+                this->offset(offset_value);
+            }
+            this->dimensions(num_of_dimensions);
         }
-        this->dimensions(num_of_dimensions);
+        catch(...)
+        {
+            (void)rocrand_destroy_generator(m_generator);
+            throw;
+        }
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)

--- a/test/test_poisson_distribution.cpp
+++ b/test/test_poisson_distribution.cpp
@@ -72,6 +72,8 @@ TEST_P(poisson_distribution_tests, mean_var)
         values[si] = v;
     }
 
+    dis.deallocate();
+
     const double mean = get_mean(values);
     const double variance = get_variance(values, mean);
 
@@ -115,6 +117,8 @@ TEST_P(poisson_distribution_tests, histogram_compare)
             historgram1[bin]++;
         }
     }
+
+    dis.deallocate();
 
     // Very loose comparison
     for (size_t bi = 0; bi < bins_count; bi++)


### PR DESCRIPTION
Fix memory leaks in rocRAND:
* test_poisson_distribution: the test requires an explicit deallocation because we test an internal implementation here (the code that uses rocRAND/hipRAND cannot cause the leak because `rocrand_destroy_discrete_distribution` deallocates memory).
* test_rocrand_cpp_wrapper and test_hiprand_cpp_wrapper: wrappers need to destroy rocrand/hiprand generators when the generator has been created correctly but setting seed/offset/dimensions throws an exception (the tests check such cases).