### PR TITLE
Fix for find_package() after GTest force install 

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -70,6 +70,7 @@ if(BUILD_TEST)
       BUILD_PROJECT       TRUE
       UPDATE_DISCONNECTED TRUE # Never update automatically from the remote repository
     )
+    list( APPEND CMAKE_PREFIX_PATH ${GTEST_ROOT} )
     find_package(GTest CONFIG REQUIRED PATHS ${GTEST_ROOT})
   endif()
 endif()


### PR DESCRIPTION
Currently in https://github.com/ROCmSoftwarePlatform/rocRAND/blob/develop/cmake/Dependencies.cmake#L73:

We call find_package in config mode and pass our local GTest install dir GTEST_ROOT as a hint via the PATHS argument.  I assume that if we're force installing GTest locally, then we want to find our local installed package first versus anything installed in system directories (ie /usr/local/lib).  

However, according to find_package documentation https://cmake.org/cmake/help/latest/command/find_package.html#full-signature-and-config-mode it looks in the cache entry <PackageName>_DIR first before anything we pass in PATHS.  If there is already a preexisting GTest install in system directories, <PackageName>_DIR seems to point to that first instead of GTEST_ROOT.  This most likely will lead to conflicts if the GTest version installed in system directories is different than what we force installed locally.

However, before checking <PackageName>_DIR, cmake will check CMAKE_PREFIX_PATH first.  So if we append GTEST_ROOT there, it solves the problem, and will otherwise fall back to system directories if for some reason nothing is found in GTEST_ROOT.

I'm not 100% this is the best way to fix this issue permanently, there are several questions that need to be answered about what we're intending when we force install and find GTest, and what we're doing in our mainline Ubuntu dockerfile, but we need a fix ASAP.