### PR TITLE
Hotfixes from release/rocm-rel-4.5 at release 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
 
-## (Unreleased) rocRAND-2.10.12 for ROCm 4.5.0
+## rocRAND-2.10.12 for ROCm 4.5.0
 ### Addded
 - Initial HIP on Windows support. See README for instructions on how to build and install.
+- Sobol64 support added.
+- Benchmark time measurement improvement
+- Address Sanitizer build option added.
 ### Changed
 - Packaging split into a runtime package called rocrand and a development package called rocrand-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
 ### Fixed
@@ -12,17 +15,10 @@ Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/e
 - Fix for order of state calls for log_normal, normal, and uniform
 ### Known issues
 - kernel_xorwow test is failing for certain GPU architectures.
-
-## [Unreleased rocRAND-2.10.11 for ROCm 4.4.0]
-### Added
-- Sobol64 support added.
-- Benchmark time measurement improvement
-- Address Sanitizer build option added.
-### Fixed
 - nvcc backend fix
 - Fix ranges of MRG32k3a device functions.
 
-## [Unreleased rocRAND-2.10.10 for ROCm 4.3.0]
+## rocRAND-2.10.10 for ROCm 4.3.0
 ### Added
 - gfx90a support added.
 - gfx1030 support added
@@ -31,11 +27,11 @@ Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/e
 - Memory leaks in Poisson tests has been fixed.
 - Memory leaks when generator has been created but setting seed/offset/dimensions throws an exception has been fixed.
 
-## [rocRAND-2.10.9 for ROCm 4.2.0]
+## rocRAND-2.10.9 for ROCm 4.2.0
 ### Fixed
 - rocRAND benchmark performance drop for xorwow has been fixed for older ROCm builds.
 
-## [rocRAND-2.10.8 for ROCm 4.1.0]
+## rocRAND-2.10.8 for ROCm 4.1.0
 ### Added
 - Ability to force install dependencies with new -d flag in install script
 ### Changed
@@ -44,31 +40,31 @@ Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/e
 - rocRAND benchmark performance drop has been fixed.
 - Debug builds via the install script have been fixed.
 
-## [rocRAND-2.10.7 for ROCm 4.0.0]
+## rocRAND-2.10.7 for ROCm 4.0.0
 ### Added
 - No new features
 
-## [rocRAND-2.10.6 for ROCm 3.10]
+## rocRAND-2.10.6 for ROCm 3.10
 ### Added
 - No new features
 
-## [rocRAND-2.10.5 for ROCm 3.9.0]
+## rocRAND-2.10.5 for ROCm 3.9.0
 ### Added
 - No new features
 
-## [rocRAND-2.10.4 for ROCm 3.8.0]
+## rocRAND-2.10.4 for ROCm 3.8.0
 ### Added
 - No new features
 
-## [rocRAND-2.10.3 for ROCm 3.7.0]
+## rocRAND-2.10.3 for ROCm 3.7.0
 ### Fixed
 - Fixed package naming to reflect OS name and architecture.
 
-## [rocRAND-2.10.2 for ROCm 3.6.0]
+## rocRAND-2.10.2 for ROCm 3.6.0
 ### Added
 - No new features
 
-## [rocRAND-2.10.1 for ROCm 3.5.0]
+## rocRAND-2.10.1 for ROCm 3.5.0
 ### Added
 - Static library build options added in beta (subject to change in build method and naming in future releases)
 ### Changed


### PR DESCRIPTION
This is an autogenerated PR.
This is intended to pull any hotfixes for ROCm release 4.5 (including changelogs and documentation) back into develop.