### PR TITLE
Change install script hipRAND download behaviour

### DIFF
--- a/install
+++ b/install
@@ -161,13 +161,12 @@ fi
 
 if($install_dependencies); then
     cmake_common_options="${cmake_common_options} -DDEPENDENCIES_FORCE_DOWNLOAD=ON"
-    if ! ($no_hiprand); then
-        git submodule update --init
-    fi
 fi
 
 if ($no_hiprand); then
     cmake_common_options="${cmake_common_options} -DBUILD_HIPRAND=OFF"
+elif ! [ -f "hipRAND/CMakeLists.txt" ]; then
+    git submodule update --init --force
 fi
 
 if [[ "${build_relocatable}" == true ]]; then


### PR DESCRIPTION
Install script will download hipRAND if
- it is trying to build hipRAND (which it is by default), and
- hipRAND/CMakeLists.txt does not exist.