### PR TITLE
Hotfix: symlinks for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
 
-## (Unreleased) rocRAND -2.10.13 for ROCm 5.1.0
+## (Unreleased) rocRAND-2.10.13 for ROCm 5.1.0
 ### Changed
 - [hipRAND](https://github.com/ROCmSoftwarePlatform/hipRAND.git) split into a separate package
 - Header file installation location changed to match other libraries.

--- a/install
+++ b/install
@@ -165,7 +165,7 @@ fi
 
 if ($no_hiprand); then
     cmake_common_options="${cmake_common_options} -DBUILD_HIPRAND=OFF"
-elif ! [ -f "hipRAND/CMakeLists.txt" ]; then
+elif ! [ -f "../../hipRAND/CMakeLists.txt" ]; then
     git submodule update --init --force
 fi
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -60,6 +60,27 @@ rocm_install(
         "${CMAKE_BINARY_DIR}/library/include"
 )
 
+# Create symlinks
+if(WIN32)
+    set(SYMLINK_COMMAND "file(COPY \${SRC} DESTINATION \${DEST_DIR})" )
+else()
+    set(SYMLINK_COMMAND "execute_process(COMMAND ln -sf \${SRC_REL} \${DEST})" )
+endif()
+set(INSTALL_SYMLINK_COMMAND "
+    set(SRC_DIR \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/include/rocrand)
+    file(GLOB_RECURSE FILES RELATIVE \${SRC_DIR} \${SRC_DIR}/*)
+    foreach(FILE \${FILES})
+        set(SRC \${SRC_DIR}/\${FILE})
+        set(DEST \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/rocrand/include/\${FILE})
+        get_filename_component(DEST_DIR \${DEST} DIRECTORY)
+        file(MAKE_DIRECTORY \${DEST_DIR})
+        file(RELATIVE_PATH SRC_REL \${DEST_DIR} \${SRC})
+        message(STATUS \"symlink: \${SRC_REL} -> \${DEST}\")
+        ${SYMLINK_COMMAND}
+    endforeach()
+")
+rocm_install(CODE "${INSTALL_SYMLINK_COMMAND}")
+
 set(FORTRAN_SRCS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/rocrand/src/fortran")
 configure_file(
     src/rocrand-fortran-config.cmake.in


### PR DESCRIPTION
Create symlinks in the old rocrand header file locations for compatibility.