### PR TITLE
Disabling launch_bounds for xorwow test cases

### DIFF
--- a/benchmark/benchmark_rocrand_kernel.cpp
+++ b/benchmark/benchmark_rocrand_kernel.cpp
@@ -625,6 +625,11 @@ const std::vector<std::string> all_distributions = {
     "discrete-custom",
 };
 
+const std::vector<std::string> all_formats = {
+    "console",
+    "csv",
+};
+
 int main(int argc, char *argv[])
 {
     cli::Parser parser(argc, argv);
@@ -654,6 +659,7 @@ int main(int argc, char *argv[])
     parser.set_optional<std::vector<std::string>>("dis", "dis", {"uniform-uint"}, distribution_desc.c_str());
     parser.set_optional<std::vector<std::string>>("engine", "engine", {"philox"}, engine_desc.c_str());
     parser.set_optional<std::vector<double>>("lambda", "lambda", {10.0}, "space-separated list of lambdas of Poisson distribution");
+    parser.set_optional<std::vector<std::string>>("format", "format", {"console"}, "output format: console, or csv");
     parser.run_and_exit_if_error();
 
     std::vector<std::string> engines;

--- a/benchmark/benchmark_rocrand_kernel.cpp
+++ b/benchmark/benchmark_rocrand_kernel.cpp
@@ -625,11 +625,6 @@ const std::vector<std::string> all_distributions = {
     "discrete-custom",
 };
 
-const std::vector<std::string> all_formats = {
-    "console",
-    "csv",
-};
-
 int main(int argc, char *argv[])
 {
     cli::Parser parser(argc, argv);
@@ -659,7 +654,7 @@ int main(int argc, char *argv[])
     parser.set_optional<std::vector<std::string>>("dis", "dis", {"uniform-uint"}, distribution_desc.c_str());
     parser.set_optional<std::vector<std::string>>("engine", "engine", {"philox"}, engine_desc.c_str());
     parser.set_optional<std::vector<double>>("lambda", "lambda", {10.0}, "space-separated list of lambdas of Poisson distribution");
-    parser.set_optional<std::vector<std::string>>("format", "format", {"console"}, "output format: console, or csv");
+
     parser.run_and_exit_if_error();
 
     std::vector<std::string> engines;

--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -53,7 +53,7 @@ void rocrand_init_kernel(GeneratorState * states,
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // causes hang/memory access fault on MI200
 void rocrand_kernel(unsigned int * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -93,7 +93,7 @@ void rocrand_uniform_kernel(float * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // causes hang/memory access fault on MI200
 void rocrand_normal_kernel(float * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -118,7 +118,7 @@ void rocrand_normal_kernel(float * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // causes hang/memory access fault on MI200
 void rocrand_log_normal_kernel(float * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;

--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -35,7 +35,7 @@
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // causes hang/memory access fault on MI200
 void rocrand_init_kernel(GeneratorState * states,
                          const size_t states_size,
                          unsigned long long seed,

--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -73,7 +73,7 @@ void rocrand_kernel(unsigned int * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+//__launch_bounds__(64) // causes hang/memory access fault on MI200
 void rocrand_uniform_kernel(float * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -143,7 +143,7 @@ void rocrand_log_normal_kernel(float * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+//__launch_bounds__(64) //causes hang/memory access fault on MI200
 void rocrand_poisson_kernel(unsigned int * output, const size_t size, double lambda)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -163,7 +163,7 @@ void rocrand_poisson_kernel(unsigned int * output, const size_t size, double lam
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+//__launch_bounds__(64) // causes hang/memory access fault on MI200
 void rocrand_discrete_kernel(unsigned int * output, const size_t size, rocrand_discrete_distribution discrete_distribution)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;


### PR DESCRIPTION
For some reason, setting __launch_bounds__(64) on the xorwow kernels in the unit tests causes either a hang, memory access fault, or incorrect results on MI200.  Until we figure out why, I am disabling the setting of launch bounds for now.