### PR TITLE
Temporarily disabling launch_bounds for xorwow unit test

### DIFF
--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -35,7 +35,7 @@
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_init_kernel(GeneratorState * states,
                          const size_t states_size,
                          unsigned long long seed,
@@ -53,7 +53,7 @@ void rocrand_init_kernel(GeneratorState * states,
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_kernel(unsigned int * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -73,7 +73,7 @@ void rocrand_kernel(unsigned int * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_uniform_kernel(float * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -93,7 +93,7 @@ void rocrand_uniform_kernel(float * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_normal_kernel(float * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -118,7 +118,7 @@ void rocrand_normal_kernel(float * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_log_normal_kernel(float * output, const size_t size)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -143,7 +143,7 @@ void rocrand_log_normal_kernel(float * output, const size_t size)
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_poisson_kernel(unsigned int * output, const size_t size, double lambda)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -163,7 +163,7 @@ void rocrand_poisson_kernel(unsigned int * output, const size_t size, double lam
 
 template <class GeneratorState>
 __global__
-__launch_bounds__(64)
+// __launch_bounds__(64) // Causes errors on MI200/HIP on Windows gfx1030
 void rocrand_discrete_kernel(unsigned int * output, const size_t size, rocrand_discrete_distribution discrete_distribution)
 {
     const unsigned int state_id = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;


### PR DESCRIPTION
For some reason having __launch_bounds__(64) is causing hangs or memory access fault or incorrect results on MI200 and HIP on Windows gfx1030.  Until we figure out why, I am temporarily removing it from affected test cases.