### PR TITLE
Remove trivial but explicit destructors

### DIFF
--- a/library/include/rocrand/rocrand_mrg32k3a.h
+++ b/library/include/rocrand/rocrand_mrg32k3a.h
@@ -74,9 +74,6 @@ public:
         float boxmuller_float; // normally distributed float
         double boxmuller_double; // normally distributed double
         #endif
-
-        FQUALIFIERS
-        ~mrg32k3a_state() { }
     };
 
     FQUALIFIERS
@@ -100,9 +97,6 @@ public:
     {
         this->seed(seed, subsequence, offset);
     }
-
-    FQUALIFIERS
-    ~mrg32k3a_engine() { }
 
     /// Reinitializes the internal state of the PRNG using new
     /// seed value \p seed_value, skips \p subsequence subsequences

--- a/library/include/rocrand/rocrand_mtgp32.h
+++ b/library/include/rocrand/rocrand_mtgp32.h
@@ -119,9 +119,6 @@ struct mtgp32_params
     unsigned int sh1_tbl[MTGP_BN_MAX];
     unsigned int sh2_tbl[MTGP_BN_MAX];
     unsigned int mask[1];
-
-    FQUALIFIERS
-    ~mtgp32_params() { }
 };
 
 typedef mtgp32_params_fast_t mtgp32_fast_params;
@@ -131,9 +128,6 @@ struct mtgp32_state
     int offset;
     int id;
     unsigned int status[MTGP_STATE];
-
-    FQUALIFIERS
-    ~mtgp32_state() { }
 };
 
 inline
@@ -180,9 +174,6 @@ public:
             single_temper_tbl[j] = params->single_temper_tbl[bid][j];
         }
     }
-
-    FQUALIFIERS
-    ~mtgp32_engine() { }
 
     FQUALIFIERS
     void copy(const mtgp32_engine * m_engine)

--- a/library/include/rocrand/rocrand_philox4x32_10.h
+++ b/library/include/rocrand/rocrand_philox4x32_10.h
@@ -111,9 +111,6 @@ public:
         float boxmuller_float; // normally distributed float
         double boxmuller_double; // normally distributed double
         #endif
-
-        FQUALIFIERS
-        ~philox4x32_10_state() { }
     };
 
     FQUALIFIERS
@@ -134,9 +131,6 @@ public:
     {
         this->seed(seed, subsequence, offset);
     }
-
-    FQUALIFIERS
-    ~philox4x32_10_engine() { }
 
     /// Reinitializes the internal state of the PRNG using new
     /// seed value \p seed_value, skips \p subsequence subsequences

--- a/library/include/rocrand/rocrand_sobol32.h
+++ b/library/include/rocrand/rocrand_sobol32.h
@@ -87,9 +87,6 @@ public:
         discard_state(offset);
     }
 
-    FQUALIFIERS
-    ~sobol32_engine() { }
-
     /// Advances the internal state to skip \p offset numbers.
     FQUALIFIERS
     void discard(unsigned int offset)

--- a/library/include/rocrand/rocrand_sobol64.h
+++ b/library/include/rocrand/rocrand_sobol64.h
@@ -87,9 +87,6 @@ public:
         discard_state(offset);
     }
 
-    FQUALIFIERS
-    ~sobol64_engine() { }
-
     /// Advances the internal state to skip \p offset numbers.
     FQUALIFIERS
     void discard(unsigned int offset)

--- a/library/include/rocrand/rocrand_xorwow.h
+++ b/library/include/rocrand/rocrand_xorwow.h
@@ -92,9 +92,6 @@ public:
 
         // Xorshift values (160 bits)
         unsigned int x[5];
-
-        FQUALIFIERS
-        ~xorwow_state() { }
     };
 
     FQUALIFIERS
@@ -138,9 +135,6 @@ public:
         m_state.boxmuller_double_state = 0;
         #endif
     }
-
-    FQUALIFIERS
-    ~xorwow_engine() { }
 
     /// Advances the internal state to skip \p offset numbers.
     FQUALIFIERS

--- a/test/test_rocrand_kernel_mrg32k3a.cpp
+++ b/test/test_rocrand_kernel_mrg32k3a.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 #include <hip/hip_runtime.h>
 
@@ -199,8 +200,11 @@ void rocrand_discrete_kernel(unsigned int * output, const size_t size, rocrand_d
 
 TEST(rocrand_kernel_mrg32k3a, rocrand_state_mrg32k3a_type)
 {
-    EXPECT_EQ(sizeof(rocrand_state_mrg32k3a), 12 * sizeof(unsigned int));
-    EXPECT_EQ(sizeof(rocrand_state_mrg32k3a[32]), 32 * sizeof(rocrand_state_mrg32k3a));
+    typedef rocrand_state_mrg32k3a state_type;
+    EXPECT_EQ(sizeof(state_type), 12 * sizeof(unsigned int));
+    EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }
 
 TEST(rocrand_kernel_mrg32k3a, rocrand)

--- a/test/test_rocrand_kernel_mtgp32.cpp
+++ b/test/test_rocrand_kernel_mtgp32.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 #include <hip/hip_runtime.h>
 
@@ -186,8 +187,11 @@ void rocrand_poisson_kernel(GeneratorState * states, unsigned int * output, cons
 
 TEST(rocrand_kernel_mtgp32, rocrand_state_mtgp32_type)
 {
-    EXPECT_EQ(sizeof(rocrand_state_mtgp32), 1078 * sizeof(unsigned int));
-    EXPECT_EQ(sizeof(rocrand_state_mtgp32[32]), 32 * sizeof(rocrand_state_mtgp32));
+    typedef rocrand_state_mtgp32 state_type;
+    EXPECT_EQ(sizeof(state_type), 1078 * sizeof(unsigned int));
+    EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }
 
 TEST(rocrand_kernel_mtgp32, rocrand)

--- a/test/test_rocrand_kernel_philox4x32_10.cpp
+++ b/test/test_rocrand_kernel_philox4x32_10.cpp
@@ -192,12 +192,17 @@ TEST(rocrand_kernel_philox4x32_10, rocrand_state_philox4x32_10_type)
     typedef rocrand_state_philox4x32_10 state_type;
     EXPECT_EQ(sizeof(state_type), 16 * sizeof(float));
     EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
-    EXPECT_TRUE(std::is_trivially_copyable<uint2>::value);
     EXPECT_TRUE(std::is_trivially_destructible<uint2>::value);
-    EXPECT_TRUE(std::is_trivially_copyable<uint4>::value);
     EXPECT_TRUE(std::is_trivially_destructible<uint4>::value);
-    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
     EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
+}
+
+TEST(rocrand_kernel_philox4x32_10, DISABLED_rocrand_state_philox4x32_10_copyable)
+{
+    typedef rocrand_state_philox4x32_10 state_type;
+    EXPECT_TRUE(std::is_trivially_copyable<uint2>::value);
+    EXPECT_TRUE(std::is_trivially_copyable<uint4>::value);
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
 }
 
 TEST(rocrand_kernel_philox4x32_10, rocrand_init)

--- a/test/test_rocrand_kernel_philox4x32_10.cpp
+++ b/test/test_rocrand_kernel_philox4x32_10.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 #include <hip/hip_runtime.h>
 
@@ -188,8 +189,11 @@ void rocrand_discrete_kernel(unsigned int * output, const size_t size, rocrand_d
 
 TEST(rocrand_kernel_philox4x32_10, rocrand_state_philox4x32_10_type)
 {
-    EXPECT_EQ(sizeof(rocrand_state_philox4x32_10), 16 * sizeof(float));
-    EXPECT_EQ(sizeof(rocrand_state_philox4x32_10[32]), 32 * sizeof(rocrand_state_philox4x32_10));
+    typedef rocrand_state_philox4x32_10 state_type;
+    EXPECT_EQ(sizeof(state_type), 16 * sizeof(float));
+    EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }
 
 TEST(rocrand_kernel_philox4x32_10, rocrand_init)

--- a/test/test_rocrand_kernel_philox4x32_10.cpp
+++ b/test/test_rocrand_kernel_philox4x32_10.cpp
@@ -192,6 +192,10 @@ TEST(rocrand_kernel_philox4x32_10, rocrand_state_philox4x32_10_type)
     typedef rocrand_state_philox4x32_10 state_type;
     EXPECT_EQ(sizeof(state_type), 16 * sizeof(float));
     EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
+    EXPECT_TRUE(std::is_trivially_copyable<uint2>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<uint2>::value);
+    EXPECT_TRUE(std::is_trivially_copyable<uint4>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<uint4>::value);
     EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
     EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }

--- a/test/test_rocrand_kernel_sobol32.cpp
+++ b/test/test_rocrand_kernel_sobol32.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 #include <hip/hip_runtime.h>
 
@@ -142,8 +143,11 @@ void rocrand_poisson_kernel(unsigned int * output, unsigned int * vectors, const
 
 TEST(rocrand_kernel_sobol32, rocrand_state_sobol32_type)
 {
-    EXPECT_EQ(sizeof(rocrand_state_sobol32), 34 * sizeof(unsigned int));
-    EXPECT_EQ(sizeof(rocrand_state_sobol32[32]), 32 * sizeof(rocrand_state_sobol32));
+    typedef rocrand_state_sobol32 state_type;
+    EXPECT_EQ(sizeof(state_type), 34 * sizeof(unsigned int));
+    EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }
 
 TEST(rocrand_kernel_sobol32, rocrand)

--- a/test/test_rocrand_kernel_sobol64.cpp
+++ b/test/test_rocrand_kernel_sobol64.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 #include <hip/hip_runtime.h>
 
@@ -142,8 +143,11 @@ void rocrand_poisson_kernel(unsigned int * output, unsigned long long int * vect
 
 TEST(rocrand_kernel_sobol64, rocrand_state_sobol64_type)
 {
-    EXPECT_EQ(sizeof(rocrand_state_sobol64), 66 * sizeof(unsigned long long int));
-    EXPECT_EQ(sizeof(rocrand_state_sobol64[32]), 32 * sizeof(rocrand_state_sobol64));
+    typedef rocrand_state_sobol64 state_type;
+    EXPECT_EQ(sizeof(state_type), 66 * sizeof(unsigned long long int));
+    EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(state_type));
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }
 
 TEST(rocrand_kernel_sobol64, rocrand)

--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -184,8 +184,11 @@ void rocrand_discrete_kernel(unsigned int * output, const size_t size, rocrand_d
 
 TEST(rocrand_kernel_xorwow, rocrand_state_xorwow_type)
 {
-    EXPECT_EQ(sizeof(rocrand_state_xorwow), 12 * sizeof(unsigned int));
-    EXPECT_EQ(sizeof(rocrand_state_xorwow[32]), 32 * sizeof(rocrand_state_xorwow));
+    typedef rocrand_state_xorwow state_type;
+    EXPECT_EQ(sizeof(state_type), 12 * sizeof(unsigned int));
+    EXPECT_EQ(sizeof(state_type[32]), 32 * sizeof(rocrand_state_xorwow));
+    EXPECT_TRUE(std::is_trivially_copyable<state_type>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<state_type>::value);
 }
 
 TEST(rocrand_kernel_xorwow, rocrand_init)

--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 #include <hip/hip_runtime.h>
 
@@ -465,6 +466,8 @@ TEST_P(rocrand_kernel_xorwow_poisson, rocrand_poisson)
 TEST_P(rocrand_kernel_xorwow_poisson, rocrand_discrete)
 {
     typedef rocrand_state_xorwow state_type;
+    static_assert(std::is_trivially_copyable<state_type>::value);
+    static_assert(std::is_trivially_destructible<state_type>::value);
 
     const double lambda = GetParam();
 

--- a/test/test_rocrand_kernel_xorwow.cpp
+++ b/test/test_rocrand_kernel_xorwow.cpp
@@ -469,8 +469,6 @@ TEST_P(rocrand_kernel_xorwow_poisson, rocrand_poisson)
 TEST_P(rocrand_kernel_xorwow_poisson, rocrand_discrete)
 {
     typedef rocrand_state_xorwow state_type;
-    static_assert(std::is_trivially_copyable<state_type>::value);
-    static_assert(std::is_trivially_destructible<state_type>::value);
 
     const double lambda = GetParam();
 


### PR DESCRIPTION
Defining destructors prevents the RNG states from being trivially copyable or destructible, which I believe makes it technically undefined behavior to assign using memcpy/hipMemcpy. Regardless, the destructor can interfere with safety checks to ensure that data being transferred to device is trivially copyable.

This issue was discovered during the recent Crusher hackathon while porting [Celeritas](https://github.com/celeritas-project/celeritas) to use HIP.