### PR TITLE
Revert enabling inline assembly from #239

### DIFF
--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -63,9 +63,7 @@ namespace detail {
       defined(__gfx904__) || \
       defined(__gfx906__) || \
       defined(__gfx908__) || \
-      defined(__gfx909__) || \
-      defined(__gfx90a__) || \
-      defined(__gfx1030__))
+      defined(__gfx909__) )
   #if !defined(ROCRAND_ENABLE_INLINE_ASM)
     #define ROCRAND_ENABLE_INLINE_ASM
   #endif


### PR DESCRIPTION
This reverts enabling inline assembly for gfx90a and gfx1030, which
was introduced as workaround for a compiler bug since fixed.
Enabling inline assembly negatively affects the performance for these
architectures in some cases.