### PR TITLE
Temporarily disabling xorwow unit test for HIP on Windows due to compiler bug

### DIFF
--- a/rtest.xml
+++ b/rtest.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testset failure-regex="[1-9]\d* tests failed">
-  <var name="CTEST_FILTER" value="ctest --output-on-failure"></var>
+  <var name="CTEST_FILTER" value="ctest --output-on-failure  --exclude-regex"></var>
+  <var name="CTEST_REGEX" value="&quot;(test_rocrand_kernel_xorwow)&quot;"></var>
   <test sets="psdb">
-    <run name="all_tests">{CTEST_FILTER}</run>
+    <run name="all_tests">{CTEST_FILTER} {CTEST_REGEX}</run>
   </test>
   <test sets="osdb">
-    <run name="all_tests">{CTEST_FILTER}</run>
+    <run name="all_tests">{CTEST_FILTER} {CTEST_REGEX}</run>
   </test>
 </testset>
 


### PR DESCRIPTION
I've filed an internal ticket with the compiler team.  Until it is resolved, we should disable the test to get CI passing again.