### PR TITLE
Add CMake HIP language support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,15 +69,6 @@ include(cmake/Dependencies.cmake)
 option(ROCRAND_CMAKE_HIP_LANGUAGE "Use CMake's HIP language support" OFF)
 if(ROCRAND_CMAKE_HIP_LANGUAGE)
   enable_language(HIP)
-  set(CMAKE_HIP_ARCHITECTURES
-    gfx803
-    gfx900:xnack-
-    gfx906:xnack-
-    gfx908:xnack-
-    gfx90a:xnack-
-    gfx90a:xnack+
-    gfx1030
-  )
 else()
   # Detect compiler support for target ID
   # This section is deprecated. Please use rocm_check_target_ids for future use.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -66,39 +66,53 @@ set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared")
 # Include cmake scripts
 include(cmake/Dependencies.cmake)
 
-# Detect compiler support for target ID
-# This section is deprecated. Please use rocm_check_target_ids for future use.
-if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-    execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--help"
-        OUTPUT_VARIABLE CXX_OUTPUT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_STRIP_TRAILING_WHITESPACE)
-    string(REGEX MATCH ".mcode\-object\-version" TARGET_ID_SUPPORT ${CXX_OUTPUT})
-endif()
-
-set( AMDGPU_TARGETS "all" CACHE STRING "Compile for which gpu architectures?")
-# Set the AMDGPU_TARGETS
-rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-    TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030"
-)
-if (AMDGPU_TARGETS)
-    if( AMDGPU_TARGETS STREQUAL "all" )
-      set( gpus "${DEFAULT_AMDGPU_TARGETS}")
-    else()
-      set( gpus "${AMDGPU_TARGETS}")
-    endif()
-    # must FORCE set this AMDGPU_TARGETS before any find_package( hip ...), in this file
-    # to override CACHE var and set --offload-arch flags via hip-config.cmake hip::device dependency
-    set( AMDGPU_TARGETS "${gpus}" CACHE STRING "AMD GPU targets to compile for" FORCE )
-endif()
-
-# Verify that hcc compiler is used on ROCM platform
-# TODO: Fix VerifyCompiler for Windows
-if (NOT WIN32)
-  include(cmake/VerifyCompiler.cmake)
+option(ROCRAND_CMAKE_HIP_LANGUAGE "Use CMake's HIP language support" OFF)
+if(ROCRAND_CMAKE_HIP_LANGUAGE)
+  enable_language(HIP)
+  set(CMAKE_HIP_ARCHITECTURES
+    gfx803
+    gfx900:xnack-
+    gfx906:xnack-
+    gfx908:xnack-
+    gfx90a:xnack-
+    gfx90a:xnack+
+    gfx1030
+  )
 else()
-  list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} $ENV{ROCM_PATH}/hip $ENV{ROCM_PATH}/llvm)
-  find_package(hip REQUIRED CONFIG PATHS ${HIP_DIR} $ENV{ROCM_PATH})
+  # Detect compiler support for target ID
+  # This section is deprecated. Please use rocm_check_target_ids for future use.
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--help"
+          OUTPUT_VARIABLE CXX_OUTPUT
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          ERROR_STRIP_TRAILING_WHITESPACE)
+      string(REGEX MATCH ".mcode\-object\-version" TARGET_ID_SUPPORT ${CXX_OUTPUT})
+  endif()
+
+  set( AMDGPU_TARGETS "all" CACHE STRING "Compile for which gpu architectures?")
+  # Set the AMDGPU_TARGETS
+  rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
+      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030"
+  )
+  if (AMDGPU_TARGETS)
+      if( AMDGPU_TARGETS STREQUAL "all" )
+        set( gpus "${DEFAULT_AMDGPU_TARGETS}")
+      else()
+        set( gpus "${AMDGPU_TARGETS}")
+      endif()
+      # must FORCE set this AMDGPU_TARGETS before any find_package( hip ...), in this file
+      # to override CACHE var and set --offload-arch flags via hip-config.cmake hip::device dependency
+      set( AMDGPU_TARGETS "${gpus}" CACHE STRING "AMD GPU targets to compile for" FORCE )
+  endif()
+
+  # Verify that hcc compiler is used on ROCM platform
+  # TODO: Fix VerifyCompiler for Windows
+  if (NOT WIN32)
+    include(cmake/VerifyCompiler.cmake)
+  else()
+    list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} $ENV{ROCM_PATH}/hip $ENV{ROCM_PATH}/llvm)
+    find_package(hip REQUIRED CONFIG PATHS ${HIP_DIR} $ENV{ROCM_PATH})
+  endif()
 endif()
 
 # Build option to disable -Werror
@@ -108,6 +122,9 @@ option(DISABLE_WERROR "Disable building with Werror" ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_HIP_STANDARD 11)
+set(CMAKE_HIP_STANDARD_REQUIRED ON)
+set(CMAKE_HIP_EXTENSIONS OFF)
 if(DISABLE_WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -mf16c")
 else()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -3,7 +3,12 @@
 # Get sources
 file(GLOB tmp ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_rocrand*.cpp)
 set(rocRAND_BENCHMARK_SRCS ${tmp})
-if(HIP_COMPILER STREQUAL "nvcc")
+if(ROCRAND_CMAKE_HIP_LANGUAGE)
+    set_source_files_properties(${rocRAND_BENCHMARK_SRCS}
+      PROPERTIES
+        LANGUAGE HIP
+    )
+elseif(HIP_COMPILER STREQUAL "nvcc")
     file(GLOB tmp ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_curand*.cpp)
     set(rocRAND_BENCHMARK_SRCS ${rocRAND_BENCHMARK_SRCS} ${tmp})
 endif()
@@ -29,7 +34,7 @@ foreach(benchmark_src ${rocRAND_BENCHMARK_SRCS})
     else()
         target_link_libraries(${BENCHMARK_TARGET}
             rocrand
-            hip::device
+            $<$<NOT:$<BOOL:ROCRAND_CMAKE_HIP_LANGUAGE>>:hip::device>
         )
     endif()
     set_target_properties(${BENCHMARK_TARGET}

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -48,11 +48,18 @@ if(HIP_COMPILER STREQUAL "nvcc")
     )
     set(CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
 else()
-    target_link_libraries(rocrand PRIVATE hip::device)
-    if(NOT WIN32)
-        foreach(amdgpu_target ${AMDGPU_TARGETS})
-            target_link_libraries(rocrand PRIVATE --amdgpu-target=${amdgpu_target})
-        endforeach()
+    if(ROCRAND_CMAKE_HIP_LANGUAGE)
+        set_source_files_properties(${rocRAND_SRCS}
+          PROPERTIES
+            LANGUAGE HIP
+        )
+    else()
+        target_link_libraries(rocrand PRIVATE hip::device)
+        if(NOT WIN32)
+            foreach(amdgpu_target ${AMDGPU_TARGETS})
+                target_link_libraries(rocrand PRIVATE --amdgpu-target=${amdgpu_target})
+            endforeach()
+        endif()
     endif()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,12 @@ endfunction()
 
 # Get rocRAND tests source files
 file(GLOB rocRAND_TEST_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+if(ROCRAND_CMAKE_HIP_LANGUAGE)
+    set_source_files_properties(${rocRAND_TEST_SRCS}
+      PROPERTIES
+        LANGUAGE HIP
+    )
+endif()
 
 # Build rocRAND tests
 foreach(test_src ${rocRAND_TEST_SRCS})
@@ -52,7 +58,9 @@ foreach(test_src ${rocRAND_TEST_SRCS})
         rocrand
     )
     if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
-        target_link_libraries(${test_name} hip::device)
+        if(NOT ROCRAND_CMAKE_HIP_LANGUAGE)
+            target_link_libraries(${test_name} hip::device)
+        endif()
     endif()
     set_target_properties(
         ${test_name}


### PR DESCRIPTION
## Build Instructions
1. Install ROCm 4.5.2
2. Install CMake 3.21.3 or later
3. Install libnuma and kmod (so that `rocm_agent_enumerator` works)
4. Build rocRAND:
```bash
HIPCXX=/opt/rocm/llvm/bin/clang++ \
CXX=/opt/rocm/llvm/bin/clang++ \
CC=/opt/rocm/llvm/bin/clang \
cmake -S. -Bbuild -GNinja \
  -DBUILD_HIPRAND=OFF \
  -DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF \
  -DROCRAND_CMAKE_HIP_LANGUAGE=ON
```

With these changes, the above command will build a version of the library compatible with the system it's running on. If you want specific GPU architectures, append `-DCMAKE_HIP_ARCHITECTURES='gfx906:xnack-;gfx1030'` (replacing the example `gfx906:xnack-;gfx1030` values with your chosen semi-colon delimited list of [AMDGPU target ids](https://llvm.org/docs/AMDGPUUsage.html#processors)).

## Related CMake Documentation
- [CMAKE_HIP_ARCHITECTURES](https://cmake.org/cmake/help/v3.23/variable/CMAKE_HIP_ARCHITECTURES.html)
- [CMAKE_HIP_STANDARD](https://cmake.org/cmake/help/v3.23/prop_tgt/CMAKE_HIP_STANDARD.html)
- [HIPCXX](https://cmake.org/cmake/help/v3.23/envvar/HIPCXX.html)