### PR TITLE
Fixing benchmark and unit test build for Windows

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -37,9 +37,9 @@ foreach(benchmark_src ${rocRAND_BENCHMARK_SRCS})
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/benchmark"
     )
     rocm_install(TARGETS ${BENCHMARK_TARGET} COMPONENT benchmarks)
-    if (WIN32 AND NOT DEFINED DLLS_COPIED)
-      set(DLLS_COPIED "YES")
-      set(DLLS_COPIED ${DLLS_COPIED} PARENT_SCOPE)
+    if (WIN32 AND NOT DEFINED DLLS_COPIED_BENCHMARKS)
+      set(DLLS_COPIED_BENCHMARKS "YES")
+      set(DLLS_COPIED_BENCHMARKS ${DLLS_COPIED_BENCHMARKS} PARENT_SCOPE)
       # for now adding in all .dll as dependency chain is not cmake based on win32
       file( GLOB third_party_dlls
       LIST_DIRECTORIES ON

--- a/benchmark/cmdparser.hpp
+++ b/benchmark/cmdparser.hpp
@@ -184,6 +184,13 @@ namespace cli {
 
             return std::stoul(elements[0]);
         }
+		
+        static unsigned long long parse(const std::vector<std::string>& elements, const unsigned long long&) {
+            if (elements.size() != 1)
+                throw std::bad_cast();
+
+            return std::stoull(elements[0]);
+        }		
 
         static long parse(const std::vector<std::string>& elements, const long&) {
             if (elements.size() != 1)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -103,8 +103,23 @@ endif()
 if (WIN32)
     install (TARGETS rocrand DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
     if (BUILD_TEST)
-        install (TARGETS rocrand DESTINATION "${PROJECT_BINARY_DIR}/test")
+	    add_custom_command(
+		    TARGET rocrand 
+		    POST_BUILD
+		    COMMAND ${CMAKE_COMMAND} -E copy
+			    $<TARGET_FILE:rocrand>
+			    ${PROJECT_BINARY_DIR}/test/$<TARGET_FILE_NAME:rocrand>
+	    )
     endif()
+    if (BUILD_BENCHMARK)
+	    add_custom_command(
+		    TARGET rocrand 
+		    POST_BUILD
+		    COMMAND ${CMAKE_COMMAND} -E copy
+			    $<TARGET_FILE:rocrand>
+			    ${PROJECT_BINARY_DIR}/benchmark/$<TARGET_FILE_NAME:rocrand>
+	    )
+    endif()	
 endif()
 
 # Fortran wrappers for hipRAND and rocRAND

--- a/rmake.py
+++ b/rmake.py
@@ -146,7 +146,7 @@ def config_cmd():
         cmake_options.append( f"-DROCM_DISABLE_LDCONFIG=ON" )
 
     if args.build_clients:
-        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_DIR={build_dir}" )
+        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DBUILD_DIR={build_dir}" )
 
     cmake_options.append( f"-DAMDGPU_TARGETS={args.gpu_architecture}" )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,9 +61,9 @@ foreach(test_src ${rocRAND_TEST_SRCS})
     )
     add_relative_test(${test_name} ${test_name})
     rocm_install(TARGETS ${test_name} COMPONENT tests)
-    if (WIN32 AND NOT DEFINED DLLS_COPIED)
-      set(DLLS_COPIED "YES")
-      set(DLLS_COPIED ${DLLS_COPIED} PARENT_SCOPE)
+    if (WIN32 AND NOT DEFINED DLLS_COPIED_TESTS)
+      set(DLLS_COPIED_TESTS "YES")
+      set(DLLS_COPIED_TESTS ${DLLS_COPIED_TESTS} PARENT_SCOPE)
       # for now adding in all .dll as dependency chain is not cmake based on win32
       file( GLOB third_party_dlls
       LIST_DIRECTORIES ON


### PR DESCRIPTION
1. Copying necessary DLLs for benchmarks and unit tests (install (TARGETS rocrand DESTINATION "${PROJECT_BINARY_DIR}/test") does not seem to work)
2. Add required function overload in Windows