### PR TITLE
Remove Git from build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Prior to ROCm version 5.0, this project included the [hipRAND](https://github.co
 
 ## Requirements
 
-* Git
-* cmake (3.16 or later)
+* CMake (3.16 or later)
 * C++ compiler with C++11 support
 * For AMD platforms:
   * [ROCm](https://rocm.github.io/install.html) (1.7 or later)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -25,12 +25,6 @@
 # HIP dependency is handled earlier in the project cmake file
 # when VerifyCompiler.cmake is included.
 
-# GIT
-find_package(Git REQUIRED)
-if(NOT Git_FOUND)
-    message(FATAL_ERROR "Please ensure Git is installed on the system")
-endif()
-
 # For downloading, building, and installing required dependencies
 include(cmake/DownloadProject.cmake)
 


### PR DESCRIPTION
The `find_package(Git REQUIRED)` doesn't seem to be used. There are some calls to `ExternalProject_Add` depending on the options (and they might require git), but they don't require this `find_package`.