### PR TITLE
Hotfixes from release/rocm-rel-5.2 at release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
 
-## (Unreleased) rocRAND-2.10.14 for ROCm 5.2.0
+## (Released) rocRAND-2.10.14 for ROCm 5.2.0
 ### Added
 - Backward compatibility for deprecated `#include <rocrand.h>` using wrapper header files.
 - Packages for test and benchmark executables on all supported OSes using CPack.


### PR DESCRIPTION
This is an autogenerated PR.
 This is intended to pull any hotfixes for ROCm release 5.2.0 (including changelogs and documentation) back into develop.