### PR TITLE
Benchmark warmup increase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log for rocRAND
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
+## (Unreleased) rocRAND-2.10.15 for ROCm 5.3.0
+### Changed
+- Increased number of warmup iterations for rocrand_benchmark_generate from 5 to 15 to eliminate corner cases that would generate artificially high benchmark scores.
 
 ## (Released) rocRAND-2.10.14 for ROCm 5.2.0
 ### Added

--- a/benchmark/benchmark_rocrand_generate.cpp
+++ b/benchmark/benchmark_rocrand_generate.cpp
@@ -91,7 +91,7 @@ void run_benchmark(const cli::Parser& parser,
     }
 
     // Warm-up
-    for (size_t i = 0; i < 10; i++)
+    for (size_t i = 0; i < 15; i++)
     {
         ROCRAND_CHECK(generate_func(generator, data, size));
     }

--- a/benchmark/benchmark_rocrand_generate.cpp
+++ b/benchmark/benchmark_rocrand_generate.cpp
@@ -91,7 +91,7 @@ void run_benchmark(const cli::Parser& parser,
     }
 
     // Warm-up
-    for (size_t i = 0; i < 5; i++)
+    for (size_t i = 0; i < 10; i++)
     {
         ROCRAND_CHECK(generate_func(generator, data, size));
     }


### PR DESCRIPTION
When running the generate benchmark on Navi21 with select distributions + engine types, we get data that fits in the L3 cache, generating artificially high benchmark scores vs. running the entire benchmark suite, which can lead to a source of confusion for end users.  As @Maetveis suggested, increasing the number of warmup iterations will stop this phenomenon from happening.