### PR TITLE
Re-enable inline asm for gfx1030

### DIFF
--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -63,7 +63,8 @@ namespace detail {
       defined(__gfx904__) || \
       defined(__gfx906__) || \
       defined(__gfx908__) || \
-      defined(__gfx909__) )
+      defined(__gfx909__) || \
+      defined(__gfx1030__) )
   #if !defined(ROCRAND_ENABLE_INLINE_ASM)
     #define ROCRAND_ENABLE_INLINE_ASM
   #endif


### PR DESCRIPTION
QA performance testing revealed that enable inline assembly actually benefits navi21 in the rocRAND philox benchmarks (the previous assessment of inline asm being bad for MI200 is still correct though).

rocrand-kernel/philox-poisson: 14.25% loss without inline asm
rocrand-kernel/philox-discrete-custom: 5.89% loss
rocrand-kernel/philox-discrete-poisson: 5.52% loss
rocrand-generate/philox-poisson: 7.68% loss


