### PR TITLE
Revert Sobol64 distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/e
 ### Fixed
 - Sobol64 now returns 64 bit instead of 32 bit random numbers.
 - Fixed a bug that prevented compiling code in C++ mode (with a host compiler) when it included the rocRAND headers on Windows.
+- ### Known issues
+- uniform, normal, and lognormal distributions for `float` produce incorrect values for Sobol 64 and Scrambled Sobol 64.
 
 ## (Unreleased) rocRAND-2.10.15 for ROCm 5.3.0
 ### Changed

--- a/library/include/rocrand/rocrand_log_normal.h
+++ b/library/include/rocrand/rocrand_log_normal.h
@@ -728,7 +728,7 @@ FQUALIFIERS
 float rocrand_log_normal(rocrand_state_sobol64* state, float mean, float stddev)
 {
     float r = rocrand_device::detail::normal_distribution(rocrand(state));
-    return exp(mean + (stddev * r));
+    return expf(mean + (stddev * r));
 }
 
 /**
@@ -766,7 +766,7 @@ FQUALIFIERS
 float rocrand_log_normal(rocrand_state_scrambled_sobol64* state, float mean, float stddev)
 {
     float r = rocrand_device::detail::normal_distribution(rocrand(state));
-    return exp(mean + (stddev * r));
+    return expf(mean + (stddev * r));
 }
 
 /**

--- a/library/include/rocrand/rocrand_normal.h
+++ b/library/include/rocrand/rocrand_normal.h
@@ -221,14 +221,6 @@ float normal_distribution(unsigned int x)
 }
 
 FQUALIFIERS
-float normal_distribution(unsigned long long int x)
-{
-    float p = ::rocrand_device::detail::uniform_distribution(x);
-    float v = ROCRAND_SQRT2 * ::rocrand_device::detail::roc_f_erfinv(2.0f * p - 1.0f);
-    return v;
-}
-
-FQUALIFIERS
 float2 normal_distribution2(unsigned int v1, unsigned int v2)
 {
     return ::rocrand_device::detail::box_muller(v1, v2);

--- a/library/include/rocrand/rocrand_uniform.h
+++ b/library/include/rocrand/rocrand_uniform.h
@@ -66,14 +66,6 @@ float uniform_distribution(unsigned int v)
     return ROCRAND_2POW32_INV + (v * ROCRAND_2POW32_INV);
 }
 
-// For unsigned long long int between 0 and ULLONG_MAX, returns value between
-// 0.0f and 1.0f, excluding 0.0f and including 1.0f.
-FQUALIFIERS
-float uniform_distribution(unsigned long long int v)
-{
-    return ROCRAND_2POW64_INV_DOUBLE + (v * ROCRAND_2POW64_INV_DOUBLE);
-}
-
 FQUALIFIERS
 float4 uniform_distribution4(uint4 v)
 {

--- a/library/src/rng/distribution/log_normal.hpp
+++ b/library/src/rng/distribution/log_normal.hpp
@@ -214,11 +214,11 @@ struct mrg_log_normal_distribution<__half>
 
 // Sobol
 
-template<class RESULT_T, typename INPUT_T>
+template<class T>
 struct sobol_log_normal_distribution;
 
-template<typename INPUT_T>
-struct sobol_log_normal_distribution<float, INPUT_T>
+template<>
+struct sobol_log_normal_distribution<float>
 {
     const float mean;
     const float stddev;
@@ -227,15 +227,16 @@ struct sobol_log_normal_distribution<float, INPUT_T>
     sobol_log_normal_distribution(float mean, float stddev)
         : mean(mean), stddev(stddev) {}
 
-    __host__ __device__ float operator()(const INPUT_T x) const
+    template<class DirectionVectorType>
+    __host__ __device__ float operator()(const DirectionVectorType x) const
     {
         float v = rocrand_device::detail::normal_distribution(x);
         return expf(mean + (stddev * v));
     }
 };
 
-template<typename INPUT_T>
-struct sobol_log_normal_distribution<double, INPUT_T>
+template<>
+struct sobol_log_normal_distribution<double>
 {
     const double mean;
     const double stddev;
@@ -244,15 +245,16 @@ struct sobol_log_normal_distribution<double, INPUT_T>
     sobol_log_normal_distribution(double mean, double stddev)
         : mean(mean), stddev(stddev) {}
 
-    __host__ __device__ double operator()(const INPUT_T x) const
+    template<class DirectionVectorType>
+    __host__ __device__ double operator()(const DirectionVectorType x) const
     {
         double v = rocrand_device::detail::normal_distribution_double(x);
         return exp(mean + (stddev * v));
     }
 };
 
-template<typename INPUT_T>
-struct sobol_log_normal_distribution<__half, INPUT_T>
+template<>
+struct sobol_log_normal_distribution<__half>
 {
     const __half mean;
     const __half stddev;
@@ -261,7 +263,8 @@ struct sobol_log_normal_distribution<__half, INPUT_T>
     sobol_log_normal_distribution(__half mean, __half stddev)
         : mean(mean), stddev(stddev) {}
 
-    __host__ __device__ __half operator()(const INPUT_T x) const
+    template<class DirectionVectorType>
+    __host__ __device__ __half operator()(const DirectionVectorType x) const
     {
         float v = rocrand_device::detail::normal_distribution(x);
         #if defined(ROCRAND_HALF_MATH_SUPPORTED)

--- a/library/src/rng/scrambled_sobol32.hpp
+++ b/library/src/rng/scrambled_sobol32.hpp
@@ -293,7 +293,7 @@ public:
     template<class T>
     rocrand_status generate_log_normal(T* data, size_t data_size, T mean, T stddev)
     {
-        sobol_log_normal_distribution<T, unsigned int> distribution(mean, stddev);
+        sobol_log_normal_distribution<T> distribution(mean, stddev);
         return generate(data, data_size, distribution);
     }
 

--- a/library/src/rng/scrambled_sobol64.hpp
+++ b/library/src/rng/scrambled_sobol64.hpp
@@ -295,7 +295,7 @@ public:
     template<class T>
     rocrand_status generate_log_normal(T* data, size_t data_size, T mean, T stddev)
     {
-        sobol_log_normal_distribution<T, unsigned long long int> distribution(mean, stddev);
+        sobol_log_normal_distribution<T> distribution(mean, stddev);
         return generate(data, data_size, distribution);
     }
 

--- a/library/src/rng/sobol32.hpp
+++ b/library/src/rng/sobol32.hpp
@@ -270,7 +270,7 @@ public:
     template<class T>
     rocrand_status generate_log_normal(T * data, size_t data_size, T mean, T stddev)
     {
-        sobol_log_normal_distribution<T, unsigned int> distribution(mean, stddev);
+        sobol_log_normal_distribution<T> distribution(mean, stddev);
         return generate(data, data_size, distribution);
     }
 

--- a/library/src/rng/sobol64.hpp
+++ b/library/src/rng/sobol64.hpp
@@ -271,7 +271,7 @@ public:
     template<class T>
     rocrand_status generate_log_normal(T * data, size_t data_size, T mean, T stddev)
     {
-        sobol_log_normal_distribution<T, unsigned long long int> distribution(mean, stddev);
+        sobol_log_normal_distribution<T> distribution(mean, stddev);
         return generate(data, data_size, distribution);
     }
 

--- a/python/rocrand/tests/rocrand_test.py
+++ b/python/rocrand/tests/rocrand_test.py
@@ -227,8 +227,9 @@ class TestGenerate(TestRNGBase):
         self.assertAlmostEqual(output.mean(), 0.5, delta=0.2)
         self.assertAlmostEqual(output.std(), math.sqrt(1 / 12.0), delta=0.2 * math.sqrt(1 / 12.0))
 
-    def test_uniform_float(self):
-        self._test_uniform(np.float32)
+    # TODO: temporarily disable float for uniform distribution
+    # def test_uniform_float(self):
+    #     self._test_uniform(np.float32)
 
     def test_uniform_double(self):
         self._test_uniform(np.float64)
@@ -240,8 +241,9 @@ class TestGenerate(TestRNGBase):
         self.assertAlmostEqual(output.mean(), 0.0, delta=0.2)
         self.assertAlmostEqual(output.std(), 1.0, delta=0.2)
 
-    def test_normal_float(self):
-        self._test_normal_real(np.float32)
+    # TODO: temporarily disable float for normal distribution
+    # def test_normal_float(self):
+    #     self._test_normal_real(np.float32)
 
     def test_normal_double(self):
         self._test_normal_real(np.float64)
@@ -258,8 +260,9 @@ class TestGenerate(TestRNGBase):
         self.assertAlmostEqual(logmean, 1.6, delta=1.6 * 0.2)
         self.assertAlmostEqual(logstd, 0.25, delta=0.25 * 0.2)
 
-    def test_lognormal_float(self):
-        self._test_lognormal_real(np.float32)
+    # TODO: temporarily disable float for lognormal distribution
+    # def test_lognormal_float(self):
+    #     self._test_lognormal_real(np.float32)
 
     def test_lognormal_double(self):
         self._test_lognormal_real(np.float64)

--- a/test/test_log_normal_distribution.cpp
+++ b/test/test_log_normal_distribution.cpp
@@ -306,7 +306,7 @@ TYPED_TEST(sobol_log_normal_distribution_tests, float_test)
 
     const size_t size = 4000;
     float val[size];
-    sobol_log_normal_distribution<float, T> u(0.2f, 0.5f);
+    sobol_log_normal_distribution<float> u(0.2f, 0.5f);
 
     // Calculate mean
     float mean = 0.0f;
@@ -341,7 +341,7 @@ TYPED_TEST(sobol_log_normal_distribution_tests, double_test)
 
     const size_t size = 4000;
     double val[size];
-    sobol_log_normal_distribution<double, T> u(0.2, 0.5);
+    sobol_log_normal_distribution<double> u(0.2, 0.5);
 
     // Calculate mean
     double mean = 0.0;
@@ -377,7 +377,7 @@ TYPED_TEST(sobol_log_normal_distribution_tests, half_test)
 
     const size_t size = 4000;
     half val[size];
-    sobol_log_normal_distribution<half, T> u(0.2f, 0.5f);
+    sobol_log_normal_distribution<half> u(0.2f, 0.5f);
 
     // Calculate mean
     float mean = 0.0f;

--- a/test/test_rocrand_kernel_scrambled_sobol64.cpp
+++ b/test/test_rocrand_kernel_scrambled_sobol64.cpp
@@ -229,26 +229,27 @@ TEST(rocrand_kernel_scrambled_sobol64, rocrand)
     EXPECT_NEAR(mean, 0.5, 0.1);
 }
 
-TEST(rocrand_kernel_scrambled_sobol64, rocrand_uniform)
-{
-    using ResultType   = float;
-    using Distribution = rocrand_uniform_f;
+// TODO: temporarily disable float for uniform distribution
+// TEST(rocrand_kernel_scrambled_sobol64, rocrand_uniform)
+// {
+//     using ResultType   = float;
+//     using Distribution = rocrand_uniform_f;
 
-    // amount of generated numbers has to be a multiple of the dimensions for sobol, so size is given per dimension
-    constexpr size_t       size_per_dimension = 8192;
-    constexpr unsigned int dimensions         = 8;
+//     // amount of generated numbers has to be a multiple of the dimensions for sobol, so size is given per dimension
+//     constexpr size_t       size_per_dimension = 8192;
+//     constexpr unsigned int dimensions         = 8;
 
-    std::vector<ResultType> output_host;
-    call_rocrand_kernel<ResultType, Distribution>(output_host, dimensions, size_per_dimension);
+//     std::vector<ResultType> output_host;
+//     call_rocrand_kernel<ResultType, Distribution>(output_host, dimensions, size_per_dimension);
 
-    double mean = 0;
-    for(ResultType v : output_host)
-    {
-        mean += static_cast<double>(v);
-    }
-    mean = mean / output_host.size();
-    EXPECT_NEAR(mean, 0.5, 0.1);
-}
+//     double mean = 0;
+//     for(ResultType v : output_host)
+//     {
+//         mean += static_cast<double>(v);
+//     }
+//     mean = mean / output_host.size();
+//     EXPECT_NEAR(mean, 0.5, 0.1);
+// }
 
 TEST(rocrand_kernel_scrambled_sobol64, rocrand_uniform_double)
 {
@@ -271,34 +272,35 @@ TEST(rocrand_kernel_scrambled_sobol64, rocrand_uniform_double)
     EXPECT_NEAR(mean, 0.5, 0.1);
 }
 
-TEST(rocrand_kernel_scrambled_sobol64, rocrand_normal)
-{
-    using ResultType   = float;
-    using Distribution = rocrand_normal_f;
+// TODO: temporarily disable float for normal distribution
+// TEST(rocrand_kernel_scrambled_sobol64, rocrand_normal)
+// {
+//     using ResultType   = float;
+//     using Distribution = rocrand_normal_f;
 
-    // amount of generated numbers has to be a multiple of the dimensions for sobol, so size is given per dimension
-    constexpr size_t       size_per_dimension = 8192;
-    constexpr unsigned int dimensions         = 8;
+//     // amount of generated numbers has to be a multiple of the dimensions for sobol, so size is given per dimension
+//     constexpr size_t       size_per_dimension = 8192;
+//     constexpr unsigned int dimensions         = 8;
 
-    std::vector<ResultType> output_host;
-    call_rocrand_kernel<ResultType, Distribution>(output_host, dimensions, size_per_dimension);
+//     std::vector<ResultType> output_host;
+//     call_rocrand_kernel<ResultType, Distribution>(output_host, dimensions, size_per_dimension);
 
-    double mean = 0;
-    for(ResultType v : output_host)
-    {
-        mean += static_cast<double>(v);
-    }
-    mean = mean / output_host.size();
-    EXPECT_NEAR(mean, 0.0, 0.2);
+//     double mean = 0;
+//     for(ResultType v : output_host)
+//     {
+//         mean += static_cast<double>(v);
+//     }
+//     mean = mean / output_host.size();
+//     EXPECT_NEAR(mean, 0.0, 0.2);
 
-    double stddev = 0;
-    for(ResultType v : output_host)
-    {
-        stddev += std::pow(static_cast<double>(v) - mean, 2);
-    }
-    stddev = stddev / output_host.size();
-    EXPECT_NEAR(stddev, 1.0, 0.2);
-}
+//     double stddev = 0;
+//     for(ResultType v : output_host)
+//     {
+//         stddev += std::pow(static_cast<double>(v) - mean, 2);
+//     }
+//     stddev = stddev / output_host.size();
+//     EXPECT_NEAR(stddev, 1.0, 0.2);
+// }
 
 TEST(rocrand_kernel_scrambled_sobol64, rocrand_normal_double)
 {

--- a/test/test_rocrand_scrambled_sobol64_qrng.cpp
+++ b/test/test_rocrand_scrambled_sobol64_qrng.cpp
@@ -38,7 +38,9 @@ struct rocrand_scrambled_sobol64_float_tests : public ::testing::Test
     using type = T;
 };
 
-using FloatReturnTypes = ::testing::Types<float, double>;
+// TODO: temporarily disable float for uniform and normal distributions
+// using FloatReturnTypes = ::testing::Types<float, double>;
+using FloatReturnTypes = ::testing::Types<double>;
 
 TYPED_TEST_SUITE(rocrand_scrambled_sobol64_float_tests, FloatReturnTypes);
 


### PR DESCRIPTION
- Revert fix for Sobol64 distributions due to disproportionally large impact on performance. Temporarily disable tests that expose this pre-existing problem.
- Change `exp` to `expf` for `float` types.
- Fix unnecessary change to `sobol_log_normal_distribution` interface.