### PR TITLE
HOTFIX: Remove backwards compatibility headers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
 option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     "${PROJECT_SOURCE_DIR}/library/include/rocrand"
     HEADER_LOCATION include/rocrand

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -24,7 +24,7 @@ configure_file(
     @ONLY
 )
 
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
     rocm_wrap_header_file(
         rocrand_version.h
         GUARDS SYMLINK WRAPPER
@@ -92,7 +92,7 @@ else()
     )
 endif()
 
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
     rocm_install(
         DIRECTORY "${PROJECT_BINARY_DIR}/library/rocrand"
         DESTINATION "."


### PR DESCRIPTION
The backwards compatibility headers should not be generated or installed on Windows.