### PR TITLE
Windows googlebench ci fix

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -85,11 +85,11 @@ if(BUILD_BENCHMARK)
     set(GOOGLEBENCHMARK_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/googlebenchmark CACHE PATH "")
     if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
       # hip-clang cannot compile googlebenchmark for some reason
-	  if(WIN32)
+      if(WIN32)
         set(COMPILER_OVERRIDE "-DCMAKE_CXX_COMPILER=cl")
       else()
         set(COMPILER_OVERRIDE "-DCMAKE_CXX_COMPILER=g++")
-	  endif()
+      endif()
     endif()
 	
     download_project(

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -83,9 +83,13 @@ if(BUILD_BENCHMARK)
       message(FATAL_ERROR "DownloadProject.cmake doesn't support multi-configuration generators.")
     endif()
     set(GOOGLEBENCHMARK_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/googlebenchmark CACHE PATH "")
-    if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (WIN32 AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))
+    if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
       # hip-clang cannot compile googlebenchmark for some reason
-      set(COMPILER_OVERRIDE "-DCMAKE_CXX_COMPILER=g++")
+	  if(WIN32)
+        set(COMPILER_OVERRIDE "-DCMAKE_CXX_COMPILER=cl")
+      else()
+        set(COMPILER_OVERRIDE "-DCMAKE_CXX_COMPILER=g++")
+	  endif()
     endif()
 	
     download_project(


### PR DESCRIPTION
The current googlebenchmark integration PR is having a build failure with the Windows CI.  I changed the override compiler for windows to be the visual studio compiler - that seems to resolve the build failure in CI, see https://github.com/ROCmSoftwarePlatform/rocRAND/pull/293.  I wanted to run the change by you guys first to make sure this change doesn't break things on your Windows dev environment.  Once the fix is in we can finally merge in the googlebenchmark integration PR.