### PR TITLE
Fix for old version rocm folder not removed on upgrade of meta packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,8 +209,6 @@ elseif( HIP_RUNTIME STREQUAL "cuda" )
     rocm_package_add_dependencies("hip-nvcc >= 3.5.0")
 endif( )
 
-set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include")
-
 if(HIP_COMPILER STREQUAL "nvcc")
     set(package_name rocrand-alt)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,8 @@ elseif( HIP_RUNTIME STREQUAL "cuda" )
     rocm_package_add_dependencies("hip-nvcc >= 3.5.0")
 endif( )
 
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" )
+
 if(HIP_COMPILER STREQUAL "nvcc")
     set(package_name rocrand-alt)
 else()


### PR DESCRIPTION
Proposed Change:

- Fix for SWDEV-344187
- Removed CPACK_PACKAGING_INSTALL_PREFIX}/include from CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION list of exclude path