### PR TITLE
HIP SDK compatibility

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/rmake.py
+++ b/rmake.py
@@ -75,6 +75,12 @@ def delete_dir(dir_path) :
         #print( linux_path )
         run_cmd( "rm" , f"-rf {linux_path}")
 
+def cmake_path(os_path):
+    if os.name == "nt":
+        return os_path.replace("\\", "/")
+    else:
+        return os.path.realpath(os_path)  
+        
 def config_cmd():
     global args
     global OS_info
@@ -88,7 +94,8 @@ def config_cmd():
     
     if (OS_info["ID"] == 'windows'):
         # we don't have ROCM on windows but have hip, ROCM can be downloaded if required
-        rocm_path = os.getenv( 'ROCM_CMAKE_PATH', "C:/github/rocm-cmake-master") #C:/hip") # rocm/Utils/cmake-rocm4.2.0"
+        raw_rocm_path = cmake_path(os.getenv('HIP_PATH', "C:/hip"))
+        rocm_path = f'"{raw_rocm_path}"' # guard against spaces in path
         cmake_executable = "cmake.exe"
         toolchain = os.path.join( src_path, "toolchain-windows.cmake" )
         #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation

--- a/rmake.py
+++ b/rmake.py
@@ -76,7 +76,7 @@ def delete_dir(dir_path) :
         run_cmd( "rm" , f"-rf {linux_path}")
 
 def cmake_path(os_path):
-    if OS_info == "nt":
+    if OS_info["ID"] == "windows":
         return os_path.replace("\\", "/")
     else:
         return os.path.realpath(os_path)  

--- a/rmake.py
+++ b/rmake.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-"""Copyright 2020-2022 Advanced Micro Devices, Inc.  All rights reserved.
+"""Copyright 2020-2023 Advanced Micro Devices, Inc.  All rights reserved.
 Manage build and installation"""
 
 import re
@@ -76,7 +76,7 @@ def delete_dir(dir_path) :
         run_cmd( "rm" , f"-rf {linux_path}")
 
 def cmake_path(os_path):
-    if os.name == "nt":
+    if OS_info == "nt":
         return os_path.replace("\\", "/")
     else:
         return os.path.realpath(os_path)  

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -3,7 +3,10 @@
 # Ninja doesn't support platform
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
-if (DEFINED ENV{HIP_DIR})
+if (DEFINED ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+elseif (DEFINED ENV{HIP_DIR})
   file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
   set(rocm_bin "${HIP_DIR}/bin")
 else()


### PR DESCRIPTION
Previously we did not account for spaces in the HIP installation path in Windows (ie. C:\Program Files, etc).