### PR TITLE
Fix Threefry4x32 and Threefry4x64 array indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log for rocRAND
 
 Full documentation for rocRAND is available at [https://rocrand.readthedocs.io/en/latest/](https://rocrand.readthedocs.io/en/latest/)
+## (Unreleased) rocRAND-2.10.18 for ROCm 5.6.0
+### Fixed
+- ThreeFry4x32 and ThreeFry4x64 now return the correct sequence of random numbers.
+
 ## (Unreleased) rocRAND-2.10.17 for ROCm 5.5.0
 ### Added
 - MT19937 pseudo random number generator based on M. Matsumoto and T. Nishimura, 1998, Mersenne Twister: A 623-dimensionally equidistributed uniform pseudorandom number generator.

--- a/library/include/rocrand/rocrand_threefry2_impl.h
+++ b/library/include/rocrand/rocrand_threefry2_impl.h
@@ -72,7 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Random seed = 1. BlockSize = 64 bits. sampleCnt =  1024. rounds =  8, minHW_or=28
 // Start: Tue Jul 12 11:11:33 2011
 // rMin = 0.334. #0206[*07] [CRC=1D9765C0. hw_OR=32. cnt=16384. blkSize=  64].format   */
-static constexpr __device__ int THREEFRY_ROTATION_32_2[] = {13, 15, 26, 6, 17, 29, 16, 24};
+static constexpr __device__ int THREEFRY_ROTATION_32_2[8] = {13, 15, 26, 6, 17, 29, 16, 24};
 
 /*
 // Output from skein_rot_search: (srs64_B64-X1000)
@@ -80,7 +80,7 @@ static constexpr __device__ int THREEFRY_ROTATION_32_2[] = {13, 15, 26, 6, 17, 2
 // Start: Tue Mar  1 10:07:48 2011
 // rMin = 0.136. #0325[*15] [CRC=455A682F. hw_OR=64. cnt=16384. blkSize= 128].format
 */
-static constexpr __device__ int THREEFRY_ROTATION_64_2[] = {16, 42, 12, 31, 16, 32, 24, 21};
+static constexpr __device__ int THREEFRY_ROTATION_64_2[8] = {16, 42, 12, 31, 16, 32, 24, 21};
 
 namespace rocrand_device
 {

--- a/library/include/rocrand/rocrand_threefry4_impl.h
+++ b/library/include/rocrand/rocrand_threefry4_impl.h
@@ -70,9 +70,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* These are the R_256 constants from the Threefish reference sources
    with names changed to R_64x4... */
-static constexpr __device__ int THREEFRY_ROTATION_64_4[][8] = {
-    {14, 52, 23,  5, 25, 46, 58, 32},
-    {16, 57, 40, 37, 33, 12, 22, 32}
+static constexpr __device__ int THREEFRY_ROTATION_64_4[8][2] = {
+    {14, 16},
+    {52, 57},
+    {23, 40},
+    { 5, 37},
+    {25, 33},
+    {46, 12},
+    {58, 22},
+    {32, 32}
 };
 
 /* Output from skein_rot_search: (srs-B128-X5000.out)
@@ -80,9 +86,15 @@ static constexpr __device__ int THREEFRY_ROTATION_64_4[][8] = {
 // Start: Mon Aug 24 22:41:36 2009
 // ...
 // rMin = 0.472. #0A4B[*33] [CRC=DD1ECE0F. hw_OR=31. cnt=16384. blkSize= 128].format    */
-static constexpr __device__ int THREEFRY_ROTATION_32_4[][8] = {
-    {10, 11, 13, 23,  6, 17, 25, 18},
-    {26, 21, 27,  5, 20, 11, 10, 20}
+static constexpr __device__ int THREEFRY_ROTATION_32_4[8][2] = {
+    {10, 26},
+    {11, 21},
+    {13, 27},
+    {23,  5},
+    { 6, 20},
+    {17, 11},
+    {25, 10},
+    {18, 20}
 };
 
 namespace rocrand_device


### PR DESCRIPTION
Corrects the array indexing for the Threefry4x32 and Threefry4x64 generators. This bug caused incorrect sequences to be produced by these two generators.