### PR TITLE
Hide symbols for GPU kernels

### DIFF
--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -37,11 +37,7 @@
 
 #include <math.h>
 
-#ifdef WIN32
 #define ROCRAND_KERNEL __global__ static
-#else
-#define ROCRAND_KERNEL __global__
-#endif
 
 #ifndef FQUALIFIERS
 #define FQUALIFIERS __forceinline__ __device__


### PR DESCRIPTION
The `-fvisibility=hidden` flag does not affect kernels and thus all `__global__` GPU functions become externally-visible symbols by default. Marking them as static will hide them.

This is not strictly necessary, since the rocrand kernels are all appropriately confined to the rocrand details namespace. However, it is still useful to hide their symbols, as it is difficult to review ABI changes between different versions of rocrand when the output of dpkg-gensymbols is full of kernels that change from release to release.