### PR TITLE
Add CodeCov Integration

### DIFF
--- a/.jenkins/codecov.groovy
+++ b/.jenkins/codecov.groovy
@@ -1,0 +1,70 @@
+#!/usr/bin/env groovy
+@Library('rocJenkins@pong') _
+import com.amd.project.*
+import com.amd.docker.*
+import java.nio.file.Path;
+
+def runCI =
+{
+    nodeDetails, jobName->
+
+    def prj = new rocProject('rocRAND', 'CodeCoverage')
+
+    def nodes = new dockerNodes(nodeDetails, jobName, prj)
+
+    def commonGroovy
+
+    boolean formatCheck = false
+
+    def compileCommand =
+    {
+        platform, project->
+
+        commonGroovy = load "${project.paths.project_src_prefix}/.jenkins/common.groovy"
+        commonGroovy.runCompileCommand(platform, project, jobName, false, false, true)
+    }
+
+    def testCommand =
+    {
+        platform, project->
+
+        commonGroovy.runCodeCovTestCommand(platform, project)
+    }
+
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, null)
+}
+
+ci: {
+    String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
+
+    def propertyList = ["compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])]]
+    propertyList = auxiliary.appendPropertyList(propertyList)
+
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([ubuntu18:['gfx900'],centos7:['gfx906'],centos8:['gfx906'],sles15sp1:['gfx908']])]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
+
+    propertyList.each
+    {
+        jobName, property->
+        if (urlJobName == jobName)
+            properties(auxiliary.addCommonProperties(property))
+    }
+
+    jobNameList.each
+    {
+        jobName, nodeDetails->
+        if (urlJobName == jobName)
+            stage(jobName) {
+                runCI(nodeDetails, jobName)
+            }
+    }
+
+    // For url job names that are not listed by the jobNameList i.e. compute-rocm-dkms-no-npi-1901
+    if(!jobNameList.keySet().contains(urlJobName))
+    {
+        properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * *')])]))
+        stage(urlJobName) {
+            runCI([ubuntu16:['gfx906']], urlJobName)
+        }
+    }
+}

--- a/.jenkins/codecov.groovy
+++ b/.jenkins/codecov.groovy
@@ -28,7 +28,7 @@ def runCI =
     {
         platform, project->
 
-        commonGroovy.runCodeCovTestCommand(platform, project)
+        commonGroovy.runCodeCovTestCommand(platform, project, jobName)
     }
 
     buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, null)

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -67,12 +67,12 @@ def runCodeCovTestCommand(platform, project)
                     #Also had to switch to using ctest so seg faults can be handled gracefully.
                     LLVM_PROFILE_FILE=./rocRand_%m.profraw ctest --output-on-failure
                     #this combines them back together.
-                    llvm-profdata merge -sparse ./test/*.profraw -o ./rocRand.profdata
+                    /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./test/*.profraw -o ./rocRand.profdata
                     #For some reason, with the -object flag, we can't just specify the source directory, so we have to filter out the files we don't want.
-                    llvm-cov report -object ./rocRollerTests -object ./librocroller.so -instr-profile=./rocRollerTests.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.report
+                    /opt/rocm/llvm/bin/llvm-cov report -object ./rocRollerTests -object ./librocroller.so -instr-profile=./rocRollerTests.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.report
                     cat ./code_cov.report
-                    #llvm-cov show -format=html -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" --output-dir=./code_cov_rocRand_html
-                    llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.txt
+                    #/opt/rocm/llvm/bin/llvm-cov show -format=html -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" --output-dir=./code_cov_rocRand_html
+                    /opt/rocm/llvm/bin/llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.txt
                     #mv ./code_cov_text/coverage/*/*/*/*/*/*/lib ./code_cov_text/lib
                     #rm -rf ./code_cov_text/coverage
                     #zip the text report for archiving.

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -70,7 +70,7 @@ def runCodeCovTestCommand(platform, project)
                     /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./test/*.profraw -o ./rocRand.profdata
                     #For some reason, with the -object flag, we can't just specify the source directory, so we have to filter out the files we don't want.
                     /opt/rocm/llvm/bin/llvm-cov report -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.report
-                    cat ./code_cov.report
+                    cat ./code_cov_rocRand.report
                     /opt/rocm/llvm/bin/llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.txt
                     curl -Os https://uploader.codecov.io/latest/linux/codecov
                     chmod +x codecov

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -57,9 +57,9 @@ def runCodeCovTestCommand(platform, project)
 {
     withCredentials([string(credentialsId: 'mathlibs-codecov-token-rocrand', variable: 'CODECOV_TOKEN')])
     {
-        String prflag = env.CHANGE_ID ? '--pr "${env.CHANGE_ID}"' : ''
+        String prflag = env.CHANGE_ID ? "--pr \"${env.CHANGE_ID}\"" : ''
         def command = """#!/usr/bin/env bash
-                    set -x
+                    set -ex
                     cd ${project.paths.project_build_prefix}/build/release
                     #Remove any extra prof files.
                     rm -rf ./*.profraw

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -78,7 +78,7 @@ def runCodeCovTestCommand(platform, project)
                     /opt/rocm/llvm/bin/llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=${profdataFile} -ignore-filename-regex="${coverageFilter}" > ${coverageFile}
                     curl -Os https://uploader.codecov.io/latest/linux/codecov
                     chmod +x codecov
-                    ./codecov -t ${CODECOV_TOKEN} ${prflag} --flags "${platform.gpu}" --file ${coverageFile} -v
+                    ./codecov -t ${CODECOV_TOKEN} ${prflag} --flags "${platform.gpu}" --sha \$(git rev-parse HEAD) --name "CodeCovPRJob" --file ${coverageFile} -v
                 """
         platform.runCommand(this, command)
     }

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -69,14 +69,9 @@ def runCodeCovTestCommand(platform, project)
                     #this combines them back together.
                     /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./test/*.profraw -o ./rocRand.profdata
                     #For some reason, with the -object flag, we can't just specify the source directory, so we have to filter out the files we don't want.
-                    /opt/rocm/llvm/bin/llvm-cov report -object ./rocRollerTests -object ./librocroller.so -instr-profile=./rocRollerTests.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.report
+                    /opt/rocm/llvm/bin/llvm-cov report -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.report
                     cat ./code_cov.report
-                    #/opt/rocm/llvm/bin/llvm-cov show -format=html -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" --output-dir=./code_cov_rocRand_html
                     /opt/rocm/llvm/bin/llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt -object ./library/librocrand.so -instr-profile=./rocRand.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.txt
-                    #mv ./code_cov_text/coverage/*/*/*/*/*/*/lib ./code_cov_text/lib
-                    #rm -rf ./code_cov_text/coverage
-                    #zip the text report for archiving.
-                    #zip -r code_cov.zip ./code_cov_text
                     curl -Os https://uploader.codecov.io/latest/linux/codecov
                     chmod +x codecov
                     ./codecov -t ${CODECOV_TOKEN} ${prflag} --flags "${platform.gpu}" --file ./ccode_cov_rocRand.txt -v

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -82,7 +82,7 @@ def runCodeCovTestCommand(platform, project, jobName)
                     /opt/rocm/llvm/bin/llvm-cov report ${objectFlags} -instr-profile=${profdataFile} -ignore-filename-regex="${coverageFilter}" > ${reportFile}
                     cat ${reportFile}
                     /opt/rocm/llvm/bin/llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt ${objectFlags} -instr-profile=${profdataFile} -ignore-filename-regex="${coverageFilter}" > ${coverageFile}
-                    
+
                     #Upload report to codecov
                     curl -Os https://uploader.codecov.io/latest/linux/codecov
                     chmod +x codecov

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -67,7 +67,7 @@ def runCodeCovTestCommand(platform, project)
                     #Also had to switch to using ctest so seg faults can be handled gracefully.
                     LLVM_PROFILE_FILE=./rocRand_%m.profraw ctest --output-on-failure
                     #this combines them back together.
-                    llvm-profdata merge -sparse ./*.profraw -o ./rocRand.profdata
+                    llvm-profdata merge -sparse ./test/*.profraw -o ./rocRand.profdata
                     #For some reason, with the -object flag, we can't just specify the source directory, so we have to filter out the files we don't want.
                     llvm-cov report -object ./rocRollerTests -object ./librocroller.so -instr-profile=./rocRollerTests.profdata -ignore-filename-regex="(.*googletest-src.*)|(.*/yaml-cpp-src/.*)|(.*hip/include.*)|(.*/include/llvm/.*)|(.*test/unit.*)|(.*/spdlog/.*)|(.*/msgpack-src/.*)" > ./code_cov_rocRand.report
                     cat ./code_cov.report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(BUILD_FORTRAN_WRAPPER "Build Fortran wrapper" OFF)
 option(BUILD_TEST "Build tests (requires googletest)" OFF)
 option(BUILD_BENCHMARK "Build benchmarks" OFF)
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
+option(CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
 
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH
@@ -126,6 +127,9 @@ if(DISABLE_WERROR)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
+if(CODE_COVERAGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+endif()
 
 # HIP on Windows: xhip is required with clang++ to get __half defined
 if (WIN32)
@@ -140,6 +144,11 @@ if(BUILD_ADDRESS_SANITIZER AND BUILD_SHARED_LIBS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
   add_link_options(-fuse-ld=lld)
+endif()
+
+
+if(CODE_COVERAGE)
+    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
 endif()
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
 if(CODE_COVERAGE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
 # HIP on Windows: xhip is required with clang++ to get __half defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
 if(CODE_COVERAGE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 endif()
 
 # HIP on Windows: xhip is required with clang++ to get __half defined
@@ -144,11 +144,6 @@ if(BUILD_ADDRESS_SANITIZER AND BUILD_SHARED_LIBS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
   add_link_options(-fuse-ld=lld)
-endif()
-
-
-if(CODE_COVERAGE)
-    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
 endif()
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rocRAND
 
+[![codecov](https://codecov.io/gh/ROCmSoftwarePlatform/rocRAND/branch/develop/graph/badge.svg?token=FdKnEdGxA1)](https://codecov.io/gh/ROCmSoftwarePlatform/rocRAND)
+
 The rocRAND project provides functions that generate pseudo-random and quasi-random numbers.
 
 The rocRAND library is implemented in the [HIP](https://github.com/ROCm-Developer-Tools/HIP)

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,7 +18,7 @@ coverage:
     range: "50...75"
 
 comment:
-    behavior: default       # if a new commit is made, update the old comment if it exists, otherwise make a new one.
+    behavior: once       # if a new commit is made, update the old comment if it exists, otherwise make a new one.
     require_changes: false  # Always post a comment, even if coverage stayed the same.
     require_base: no        # Always post, even without a base to compare.
     require_head: no        # Always post, even without a head to compare.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+ignore:
+  - "benchmark/"
+  - "build/" 
+  - "cmake/"
+  - "docs/"
+  - "hipRAND/" 
+  - "python/" 
+  - "scripts/" 
+  - "test/" 
+  - "tools/" 
+
+coverage:
+    precision: 2
+    round: nearest
+    range: "50...75"
+
+comment:
+    behavior: new           # if a new commit is made, delete old comment and make a new one.
+    require_changes: false  # Always post a comment, even if coverage stayed the same.
+    require_base: no        # Always post, even without a base to compare.
+    require_head: no        # Always post, even without a head to compare.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,5 @@
 codecov:
   require_ci_to_pass: false
-  notify:
-    after_n_builds: 2
-    wait_for_ci: no
 
 ignore:
   - "benchmark/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  require_ci_to_pass: false
+  notify:
+    after_n_builds: 2
+    wait_for_ci: no
+
 ignore:
   - "benchmark/"
   - "build/" 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,14 +6,14 @@ codecov:
 
 ignore:
   - "benchmark/"
-  - "build/" 
+  - "build/"
   - "cmake/"
   - "docs/"
-  - "hipRAND/" 
-  - "python/" 
-  - "scripts/" 
-  - "test/" 
-  - "tools/" 
+  - "hipRAND/"
+  - "python/"
+  - "scripts/"
+  - "test/"
+  - "tools/"
 
 coverage:
     precision: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,7 +18,7 @@ coverage:
     range: "50...75"
 
 comment:
-    behavior: new           # if a new commit is made, delete old comment and make a new one.
+    behavior: default       # if a new commit is made, update the old comment if it exists, otherwise make a new one.
     require_changes: false  # Always post a comment, even if coverage stayed the same.
     require_base: no        # Always post, even without a base to compare.
     require_head: no        # Always post, even without a head to compare.


### PR DESCRIPTION
This PR does the following:

- adds a `CODE_COVERAGE` flag to the cmake file, which will build with code coverage enabled if building with clang
- adds a codecov jenkins job which will build with the `CODE_COVERAGE` flag on, run the unit tests, collect the coverage results, and upload them to codecov.
    - This will track coverage on master and codecov will post a comment on each PR with the impact that the PR has on code coverage.
- adds a codecov.yml file to set options for codecov.
- adds the codecov coverage badge to the main readme.