### PR TITLE
Remove build dependency on Git

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -28,12 +28,6 @@
 # For downloading, building, and installing required dependencies
 include(cmake/DownloadProject.cmake)
 
-# GIT
-find_package(Git REQUIRED)
-if (NOT Git_FOUND)
-  message(FATAL_ERROR "Please ensure Git is installed on the system")
-endif()
-
 if(USE_HIP_CPU)
   find_package(Threads REQUIRED)
 


### PR DESCRIPTION
The rocRAND project might use Git to download dependencies, but it is not required if the dependencies are already installed. And, even in the case that Git is needed to download dependencies, this find_package call remains unnecessary. The tooling that does the downloads will look for git itself.

This is the same change as #273, as it was reverted by #300.