### PR TITLE
Roblemos/inline assembly fix

### DIFF
--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -68,7 +68,6 @@ namespace detail {
 #else
   #if defined(__HIP_DEVICE_COMPILE__) && defined(ROCRAND_ENABLE_INLINE_ASM)
     #undef ROCRAND_ENABLE_INLINE_ASM
-    #warning "Disabled inline asm, because the build target does not support it."
   #endif
 #endif
 

--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -65,6 +65,11 @@ namespace detail {
   #if !defined(ROCRAND_ENABLE_INLINE_ASM)
     #define ROCRAND_ENABLE_INLINE_ASM
   #endif
+#else
+  #if defined(__HIP_DEVICE_COMPILE__) && defined(ROCRAND_ENABLE_INLINE_ASM)
+    #undef ROCRAND_ENABLE_INLINE_ASM
+    #warning "Disabled inline asm, because the build target does not support it."
+  #endif
 #endif
 
 FQUALIFIERS


### PR DESCRIPTION
The previous PR #332 accidentally enable the inline assembly for MI200 which reduces performance for some benchmarks and this PR revert that change. 