### PR TITLE
5.6 cherry pick - fix inline assembly

### DIFF
--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -65,6 +65,10 @@ namespace detail {
   #if !defined(ROCRAND_ENABLE_INLINE_ASM)
     #define ROCRAND_ENABLE_INLINE_ASM
   #endif
+#else
+  #if defined(__HIP_DEVICE_COMPILE__) && defined(ROCRAND_ENABLE_INLINE_ASM)
+    #undef ROCRAND_ENABLE_INLINE_ASM
+  #endif
 #endif
 
 FQUALIFIERS


### PR DESCRIPTION
This 5.6 Cherry Pick fix inline assembly so that the it is disable for MI200.