### PR TITLE
sobol64_direction_vector_generator.cpp: include stdint.h for uint*_t

### DIFF
--- a/tools/scrambled_sobol32_direction_vector_generator.cpp
+++ b/tools/scrambled_sobol32_direction_vector_generator.cpp
@@ -21,6 +21,7 @@
 #include "../library/include/rocrand/rocrand_sobol32_precomputed.h"
 #include <fstream>
 #include <iomanip>
+#include <cstdint>
 #include <iostream>
 #include <string>
 

--- a/tools/scrambled_sobol64_direction_vector_generator.cpp
+++ b/tools/scrambled_sobol64_direction_vector_generator.cpp
@@ -21,6 +21,7 @@
 #include "../library/include/rocrand/rocrand_sobol64_precomputed.h"
 #include <fstream>
 #include <iomanip>
+#include <cstdint>
 #include <iostream>
 #include <string>
 

--- a/tools/sobol32_direction_vector_generator.cpp
+++ b/tools/sobol32_direction_vector_generator.cpp
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cstdint>
 #include <string>
 #include <iomanip>
 

--- a/tools/sobol64_direction_vector_generator.cpp
+++ b/tools/sobol64_direction_vector_generator.cpp
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cstdint>
 #include <string>
 #include <iomanip>
 


### PR DESCRIPTION
Reference: https://gcc.gnu.org/gcc-13/porting_to.html