### PR TITLE
366827 - Disable file reorg backward compatibility support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if(BUILD_ADDRESS_SANITIZER AND BUILD_SHARED_LIBS)
 endif()
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     "${PROJECT_SOURCE_DIR}/library/include/rocrand"

--- a/install
+++ b/install
@@ -35,7 +35,7 @@ build_relocatable=false
 install_dependencies=false
 build_address_sanitizer=false
 no_hiprand=false
-build_freorg_bkwdcomp=true
+build_freorg_bkwdcomp=false
 
 # #################################################
 # Parameter parsing


### PR DESCRIPTION
Change Proposed:
- File Reorg backward compatibility option set to OFF
- Backward Compatibility flag in install script set to false by default.