### PR TITLE
Hide library internal symbols

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -59,6 +59,11 @@ endif()
 add_library(rocrand ${rocRAND_SRCS})
 add_library(roc::rocrand ALIAS rocrand)
 
+set_target_properties(rocrand PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
+
 # Add interface include directory so that other CMake applications can maintain previous behaviour.
 # This will be removed with upcoming packaging changes.
 target_include_directories(rocrand INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/rocrand>)

--- a/library/include/rocrand/rocrandapi.h
+++ b/library/include/rocrand/rocrandapi.h
@@ -12,7 +12,7 @@
             #define ROCRANDAPI __declspec(dllimport)
         #endif
     #else
-        #define ROCRANDAPI
+        #define ROCRANDAPI __attribute__((visibility("default")))
     #endif
 #endif
 /// \endcond


### PR DESCRIPTION
On Windows, the default compiler behaviour is to hide symbols and exported symbols must be marked explicitly as being exported. On Linux, the default compiler behaviour is to make all symbols visible by default. The default can be changed by setting the `CXX_VISIBILITY_PRESET` CMake property on the library to add `-fvisibility=hidden` to the compiler options. This makes Linux work like Windows in that only the symbols explicitly marked for export are publicly visible.

When only symbols intended to be part of the public ABI are visible, it makes it much easier to review changes, because it means that any removal is a breaking change (whereas currently you need to check if the removal corresponds to a function declared in the public headers to know).