### PR TITLE
Add Codeowners for Documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-# documentation files
+# Documentation files
 docs/* @saadrahim @LisaDelaney
 *.md  @saadrahim @LisaDelaney
 *.rst  @saadrahim @LisaDelaney
+# Header directory
 library/include/*  @saadrahim @LisaDelaney

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# documentation files
+docs/* @ROCmSoftwarePlatform/technical-writers
+*.md @ROCmSoftwarePlatform/technical-writers
+*.rst @ROCmSoftwarePlatform/technical-writers
+library/include/* @ROCmSoftwarePlatform/technical-writers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # documentation files
-docs/* @ROCmSoftwarePlatform/technical-writers
-*.md @ROCmSoftwarePlatform/technical-writers
-*.rst @ROCmSoftwarePlatform/technical-writers
-library/include/* @ROCmSoftwarePlatform/technical-writers
+docs/* @saadrahim @LisaDelaney
+*.md  @saadrahim @LisaDelaney
+*.rst  @saadrahim @LisaDelaney
+library/include/*  @saadrahim @LisaDelaney

--- a/.github/CODEOWNERS~
+++ b/.github/CODEOWNERS~
@@ -1,0 +1,5 @@
+# documentation files
+docs/* @ROCmSoftwarePlatform/technical-writers
+*.md @ROCmSoftwarePlatform/technical-writers
+*.rst @ROCmSoftwarePlatform/technical-writers
+library/include/* @ROCmSoftwarePlatform/technical-writers

--- a/.github/CODEOWNERS~
+++ b/.github/CODEOWNERS~
@@ -1,5 +1,0 @@
-# documentation files
-docs/* @ROCmSoftwarePlatform/technical-writers
-*.md @ROCmSoftwarePlatform/technical-writers
-*.rst @ROCmSoftwarePlatform/technical-writers
-library/include/* @ROCmSoftwarePlatform/technical-writers


### PR DESCRIPTION
Adding code owners for documentation. Plan is to add mandatory reviews from this group of code owners to merge any documentation changes. 

The header directory is related to documentation and thus changes to that are also flagged for documentation review.