### PR TITLE
Fix CppCheck Issues

### DIFF
--- a/benchmark/benchmark_rocrand_device_api.cpp
+++ b/benchmark/benchmark_rocrand_device_api.cpp
@@ -620,7 +620,7 @@ struct generator_uint : public generator_type
         return "uniform-uint";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand(state);
     }
@@ -636,7 +636,7 @@ struct generator_ullong : public generator_type
         return "uniform-ullong";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand(state);
     }
@@ -652,7 +652,7 @@ struct generator_uniform : public generator_type
         return "uniform-float";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand_uniform(state);
     }
@@ -668,7 +668,7 @@ struct generator_uniform_double : public generator_type
         return "uniform-double";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand_uniform_double(state);
     }
@@ -684,7 +684,7 @@ struct generator_normal : public generator_type
         return "normal-float";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand_normal(state);
     }
@@ -700,7 +700,7 @@ struct generator_normal_double : public generator_type
         return "normal-double";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand_normal_double(state);
     }
@@ -716,7 +716,7 @@ struct generator_log_normal : public generator_type
         return "log-normal-float";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand_log_normal(state, 0.f, 1.f);
     }
@@ -732,7 +732,7 @@ struct generator_log_normal_double : public generator_type
         return "log-normal-double";
     }
 
-    __device__ data_type operator()(Engine* state)
+    __device__ data_type operator()(Engine* state) const
     {
         return rocrand_log_normal_double(state, 0., 1.);
     }

--- a/benchmark/benchmark_rocrand_device_api.cpp
+++ b/benchmark/benchmark_rocrand_device_api.cpp
@@ -605,9 +605,9 @@ struct runner<rocrand_state_scrambled_sobol64>
 // Provide optional create and destroy functions for the generators.
 struct generator_type
 {
-    void create() {}
+    static void create() {}
 
-    void destroy() {}
+    static void destroy() {}
 };
 
 template<typename Engine>

--- a/benchmark/benchmark_rocrand_generate.cpp
+++ b/benchmark/benchmark_rocrand_generate.cpp
@@ -354,7 +354,7 @@ int main(int argc, char *argv[])
     const std::string distribution_desc =
         "space-separated list of distributions:" +
         std::accumulate(all_distributions.begin(), all_distributions.end(), std::string(),
-            [](std::string a, std::string b) {
+            [](const std::string& a, const std::string& b) {
                 return a + "\n      " + b;
             }
         ) +
@@ -362,7 +362,7 @@ int main(int argc, char *argv[])
     const std::string engine_desc =
         "space-separated list of random number engines:" +
         std::accumulate(all_engines.begin(), all_engines.end(), std::string(),
-            [](std::string a, std::string b) {
+            [](const std::string& a, const std::string& b) {
                 return a + "\n      " + b;
             }
         ) +
@@ -372,8 +372,8 @@ int main(int argc, char *argv[])
     parser.set_optional<size_t>("dimensions", "dimensions", 1, "number of dimensions of quasi-random values");
     parser.set_optional<size_t>("offset", "offset", 0, "offset of generated pseudo-random values");
     parser.set_optional<size_t>("trials", "trials", 20, "number of trials");
-    parser.set_optional<std::vector<std::string>>("dis", "dis", {"uniform-uint"}, distribution_desc.c_str());
-    parser.set_optional<std::vector<std::string>>("engine", "engine", {"philox"}, engine_desc.c_str());
+    parser.set_optional<std::vector<std::string>>("dis", "dis", {"uniform-uint"}, distribution_desc);
+    parser.set_optional<std::vector<std::string>>("engine", "engine", {"philox"}, engine_desc);
     parser.set_optional<std::vector<double>>("lambda", "lambda", {10.0}, "space-separated list of lambdas of Poisson distribution");
     parser.set_optional<std::string>("format", "format", {"console"}, "output format: console or csv");
     parser.run_and_exit_if_error();

--- a/benchmark/benchmark_rocrand_kernel.cpp
+++ b/benchmark/benchmark_rocrand_kernel.cpp
@@ -262,6 +262,7 @@ struct runner<rocrand_state_lfsr113>
            const unsigned long long /* seed */,
            const unsigned long long /* offset */)
     {
+        this->dimensions = 0;
         const size_t states_size = blocks * threads;
         HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&states),
                             states_size * sizeof(rocrand_state_lfsr113)));
@@ -954,7 +955,7 @@ int main(int argc, char *argv[])
     const std::string distribution_desc =
         "space-separated list of distributions:" +
         std::accumulate(all_distributions.begin(), all_distributions.end(), std::string(),
-            [](std::string a, std::string b) {
+            [](const std::string& a, const std::string& b) {
                 return a + "\n      " + b;
             }
         ) +
@@ -962,7 +963,7 @@ int main(int argc, char *argv[])
     const std::string engine_desc =
         "space-separated list of random number engines:" +
         std::accumulate(all_engines.begin(), all_engines.end(), std::string(),
-            [](std::string a, std::string b) {
+            [](const std::string& a, const std::string& b) {
                 return a + "\n      " + b;
             }
         ) +
@@ -973,8 +974,8 @@ int main(int argc, char *argv[])
     parser.set_optional<size_t>("trials", "trials", 20, "number of trials");
     parser.set_optional<size_t>("blocks", "blocks", 256, "number of blocks");
     parser.set_optional<size_t>("threads", "threads", 256, "number of threads in each block");
-    parser.set_optional<std::vector<std::string>>("dis", "dis", {"uniform-uint"}, distribution_desc.c_str());
-    parser.set_optional<std::vector<std::string>>("engine", "engine", {"philox"}, engine_desc.c_str());
+    parser.set_optional<std::vector<std::string>>("dis", "dis", {"uniform-uint"}, distribution_desc);
+    parser.set_optional<std::vector<std::string>>("engine", "engine", {"philox"}, engine_desc);
     parser.set_optional<std::vector<double>>("lambda", "lambda", {10.0}, "space-separated list of lambdas of Poisson distribution");
     parser.set_optional<std::string>("format", "format", {"console"}, "output format: console or csv");
     parser.run_and_exit_if_error();

--- a/benchmark/cmdparser.hpp
+++ b/benchmark/cmdparser.hpp
@@ -95,7 +95,7 @@ namespace cli {
                 CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic) {
             }
 
-            virtual bool parse(std::ostream& output, std::ostream& error) {
+            bool parse(std::ostream& output, std::ostream& error) override {
                 try {
                     CallbackArgs args { arguments, output, error };
                     value = callback(args);
@@ -105,7 +105,7 @@ namespace cli {
                 }
             }
 
-            virtual std::string print_value() const {
+            std::string print_value() const override {
                 return "";
             }
 
@@ -120,7 +120,7 @@ namespace cli {
                 CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic) {
             }
 
-            virtual bool parse(std::ostream&, std::ostream&) {
+            bool parse(std::ostream&, std::ostream&) override {
                 try {
                     value = Parser::parse(arguments, value);
                     return true;
@@ -129,11 +129,11 @@ namespace cli {
                 }
             }
 
-            virtual std::string print_value() const {
+            std::string print_value() const override {
                 return stringify(value);
             }
 
-            T value;
+            T value {};
         };
 
         static int parse(const std::vector<std::string>& elements, const int&) {
@@ -305,7 +305,7 @@ namespace cli {
         }
 
         template<typename T>
-        void set_optional(const std::string& name, const std::string& alternative, T defaultValue, const std::string& description = "", bool dominant = false) {
+        void set_optional(const std::string& name, const std::string& alternative, const T& defaultValue, const std::string& description = "", bool dominant = false) {
             auto command = new CmdArgument<T> { name, alternative, description, false, dominant };
             command->value = defaultValue;
             _commands.push_back(command);

--- a/library/include/rocrand/rocrand.hpp
+++ b/library/include/rocrand/rocrand.hpp
@@ -55,7 +55,7 @@ public:
     /// Constructs new error object from error code \p error.
     ///
     /// \param error - error code
-    error(error_type error) noexcept
+    explicit error(error_type error) noexcept
         : m_error(error),
           m_error_string(to_string(error))
     {
@@ -161,11 +161,12 @@ public:
     }
 
     /// Resets distribution's internal state if there is any.
-    void reset()
+    static void reset()
     {
     }
 
     /// Returns the smallest possible value that can be generated.
+    // cppcheck-suppress functionStatic
     IntType min() const
     {
         return 0;
@@ -203,39 +204,39 @@ public:
     }
 
     /// Returns \c true if the distribution is the same as \p other.
-    bool operator==(const uniform_int_distribution<IntType>& other)
+    bool operator==(const uniform_int_distribution<IntType>& other) const
     {
         (void) other;
         return true;
     }
 
     /// Returns \c true if the distribution is different from \p other.
-    bool operator!=(const uniform_int_distribution<IntType>& other)
+    bool operator!=(const uniform_int_distribution<IntType>& other) const
     {
         return !(*this == other);
     }
 
 private:
     template<class Generator>
-    rocrand_status generate(Generator& g, unsigned char * output, size_t size)
+    static rocrand_status generate(Generator& g, unsigned char * output, size_t size)
     {
         return rocrand_generate_char(g.m_generator, output, size);
     }
 
     template<class Generator>
-    rocrand_status generate(Generator& g, unsigned short * output, size_t size)
+    static rocrand_status generate(Generator& g, unsigned short * output, size_t size)
     {
         return rocrand_generate_short(g.m_generator, output, size);
     }
 
     template<class Generator>
-    rocrand_status generate(Generator& g, unsigned int * output, size_t size)
+    static rocrand_status generate(Generator& g, unsigned int * output, size_t size)
     {
         return rocrand_generate(g.m_generator, output, size);
     }
 
     template<class Generator>
-    rocrand_status generate(Generator& g, unsigned long long int* output, size_t size)
+    static rocrand_status generate(Generator& g, unsigned long long int* output, size_t size)
     {
         return rocrand_generate_long_long(g.m_generator, output, size);
     }
@@ -266,11 +267,12 @@ public:
     }
 
     /// Resets distribution's internal state if there is any.
-    void reset()
+    static void reset()
     {
     }
 
     /// Returns the smallest possible value that can be generated.
+    // cppcheck-suppress functionStatic
     RealType min() const
     {
         if(std::is_same<float, RealType>::value)
@@ -281,6 +283,7 @@ public:
     }
 
     /// Returns the largest possible value that can be generated.
+    // cppcheck-suppress functionStatic
     RealType max() const
     {
         return 1.0;
@@ -312,33 +315,33 @@ public:
     }
 
     /// Returns \c true if the distribution is the same as \p other.
-    bool operator==(const uniform_real_distribution<RealType>& other)
+    bool operator==(const uniform_real_distribution<RealType>& other) const
     {
         (void) other;
         return true;
     }
 
     /// Returns \c true if the distribution is different from \p other.
-    bool operator!=(const uniform_real_distribution<RealType>& other)
+    bool operator!=(const uniform_real_distribution<RealType>& other) const
     {
         return !(*this == other);
     }
 
 private:
     template<class Generator>
-    rocrand_status generate(Generator& g, float * output, size_t size)
+    static rocrand_status generate(Generator& g, float * output, size_t size)
     {
         return rocrand_generate_uniform(g.m_generator, output, size);
     }
 
     template<class Generator>
-    rocrand_status generate(Generator& g, double * output, size_t size)
+    static rocrand_status generate(Generator& g, double * output, size_t size)
     {
         return rocrand_generate_uniform_double(g.m_generator, output, size);
     }
 
     template<class Generator>
-    rocrand_status generate(Generator& g, half * output, size_t size)
+    static rocrand_status generate(Generator& g, half * output, size_t size)
     {
         return rocrand_generate_uniform_half(g.m_generator, output, size);
     }
@@ -400,13 +403,13 @@ public:
         }
 
         /// Returns \c true if the param_type is the same as \p other.
-        bool operator==(const param_type& other)
+        bool operator==(const param_type& other) const
         {
             return m_mean == other.m_mean && m_stddev == other.m_stddev;
         }
 
         /// Returns \c true if the param_type is different from \p other.
-        bool operator!=(const param_type& other)
+        bool operator!=(const param_type& other) const
         {
             return !(*this == other);
         }
@@ -425,13 +428,13 @@ public:
 
     /// \brief Constructs a new distribution object.
     /// \param params - Distribution parameters
-    normal_distribution(const param_type& params)
+    explicit normal_distribution(const param_type& params)
         : m_params(params)
     {
     }
 
     /// Resets distribution's internal state if there is any.
-    void reset()
+    static void reset()
     {
     }
 
@@ -452,6 +455,7 @@ public:
     }
 
     /// Returns the smallest possible value that can be generated.
+    // cppcheck-suppress functionStatic
     RealType min() const
     {
         return std::numeric_limits<RealType>::lowest();
@@ -504,7 +508,7 @@ public:
     /// \brief Returns \c true if the distribution is the same as \p other.
     ///
     /// Two distribution are equal, if their parameters are equal.
-    bool operator==(const normal_distribution<RealType>& other)
+    bool operator==(const normal_distribution<RealType>& other) const 
     {
         return this->m_params == other.m_params;
     }
@@ -512,7 +516,7 @@ public:
     /// \brief Returns \c true if the distribution is different from \p other.
     ///
     /// Two distribution are equal, if their parameters are equal.
-    bool operator!=(const normal_distribution<RealType>& other)
+    bool operator!=(const normal_distribution<RealType>& other) const
     {
         return !(*this == other);
     }
@@ -601,13 +605,13 @@ public:
         }
 
         /// Returns \c true if the param_type is the same as \p other.
-        bool operator==(const param_type& other)
+        bool operator==(const param_type& other) const
         {
             return m_mean == other.m_mean && m_stddev == other.m_stddev;
         }
 
         /// Returns \c true if the param_type is different from \p other.
-        bool operator!=(const param_type& other)
+        bool operator!=(const param_type& other) const
         {
             return !(*this == other);
         }
@@ -626,13 +630,13 @@ public:
 
     /// \brief Constructs a new distribution object.
     /// \param params - Distribution parameters
-    lognormal_distribution(const param_type& params)
+    explicit lognormal_distribution(const param_type& params)
         : m_params(params)
     {
     }
 
     /// Resets distribution's internal state if there is any.
-    void reset()
+    static void reset()
     {
     }
 
@@ -665,6 +669,7 @@ public:
     }
 
     /// Returns the smallest possible value that can be generated.
+    // cppcheck-suppress functionStatic
     RealType min() const
     {
         return 0;
@@ -706,7 +711,7 @@ public:
     /// \brief Returns \c true if the distribution is the same as \p other.
     ///
     /// Two distribution are equal, if their parameters are equal.
-    bool operator==(const lognormal_distribution<RealType>& other)
+    bool operator==(const lognormal_distribution<RealType>& other) const
     {
         return this->m_params == other.m_params;
     }
@@ -714,7 +719,7 @@ public:
     /// \brief Returns \c true if the distribution is different from \p other.
     ///
     /// Two distribution are equal, if their parameters are equal.
-    bool operator!=(const lognormal_distribution<RealType>& other)
+    bool operator!=(const lognormal_distribution<RealType>& other) const
     {
         return !(*this == other);
     }
@@ -793,13 +798,13 @@ public:
         }
 
         /// Returns \c true if the param_type is the same as \p other.
-        bool operator==(const param_type& other)
+        bool operator==(const param_type& other) const
         {
             return m_mean == other.m_mean;
         }
 
         /// Returns \c true if the param_type is different from \p other.
-        bool operator!=(const param_type& other)
+        bool operator!=(const param_type& other) const
         {
             return !(*this == other);
         }
@@ -817,13 +822,13 @@ public:
 
     /// \brief Constructs a new distribution object.
     /// \param params - Distribution parameters
-    poisson_distribution(const param_type& params)
+    explicit poisson_distribution(const param_type& params)
         : m_params(params)
     {
     }
 
     /// Resets distribution's internal state if there is any.
-    void reset()
+    static void reset()
     {
     }
 
@@ -837,6 +842,7 @@ public:
     }
 
     /// Returns the smallest possible value that can be generated.
+    // cppcheck-suppress functionStatic
     IntType min() const
     {
         return 0;
@@ -889,7 +895,7 @@ public:
     /// \brief Returns \c true if the distribution is the same as \p other.
     ///
     /// Two distribution are equal, if their parameters are equal.
-    bool operator==(const poisson_distribution<IntType>& other)
+    bool operator==(const poisson_distribution<IntType>& other) const
     {
         return this->m_params == other.m_params;
     }
@@ -897,7 +903,7 @@ public:
     /// \brief Returns \c true if the distribution is different from \p other.
     ///
     /// Two distribution are equal, if their parameters are equal.
-    bool operator!=(const poisson_distribution<IntType>& other)
+    bool operator!=(const poisson_distribution<IntType>& other) const
     {
         return !(*this == other);
     }
@@ -976,7 +982,7 @@ public:
     /// bound to the lifetime of the engine.
     ///
     /// \param generator - rocRAND generator
-    philox4x32_10_engine(rocrand_generator& generator)
+    explicit philox4x32_10_engine(rocrand_generator& generator)
         : m_generator(generator)
     {
         if(generator == NULL)
@@ -1109,6 +1115,7 @@ public:
     }
 
     /// Returns the smallest possible value that can be generated by the engine.
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -1197,7 +1204,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    xorwow_engine(rocrand_generator& generator)
+    explicit xorwow_engine(rocrand_generator& generator)
         : m_generator(generator)
     {
         if(generator == NULL)
@@ -1276,6 +1283,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -1365,7 +1373,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    mrg31k3p_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit mrg31k3p_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -1447,6 +1455,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 1;
@@ -1536,7 +1545,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    mrg32k3a_engine(rocrand_generator& generator)
+    explicit mrg32k3a_engine(rocrand_generator& generator)
         : m_generator(generator)
     {
         if(generator == NULL)
@@ -1615,6 +1624,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 1;
@@ -1706,7 +1716,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    mtgp32_engine(rocrand_generator& generator)
+    explicit mtgp32_engine(rocrand_generator& generator)
         : m_generator(generator)
     {
         if(generator == NULL)
@@ -1778,6 +1788,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -1871,7 +1882,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    lfsr113_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit lfsr113_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -1953,6 +1964,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -2038,7 +2050,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    mt19937_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit mt19937_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -2104,6 +2116,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -2201,7 +2214,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    sobol32_engine(rocrand_generator& generator)
+    explicit sobol32_engine(rocrand_generator& generator)
         : m_generator(generator)
     {
         if(generator == NULL)
@@ -2304,6 +2317,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -2403,7 +2417,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    scrambled_sobol32_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit scrambled_sobol32_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -2509,6 +2523,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -2607,7 +2622,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    sobol64_engine(rocrand_generator& generator)
+    explicit sobol64_engine(rocrand_generator& generator)
         : m_generator(generator)
     {
         if(generator == NULL)
@@ -2710,6 +2725,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -2809,7 +2825,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    scrambled_sobol64_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit scrambled_sobol64_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -2915,6 +2931,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -3004,7 +3021,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    threefry2x32_20_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit threefry2x32_20_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -3086,6 +3103,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -3175,7 +3193,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    threefry2x64_20_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit threefry2x64_20_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -3257,6 +3275,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -3346,7 +3365,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    threefry4x32_20_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit threefry4x32_20_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -3428,6 +3447,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;
@@ -3517,7 +3537,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::philox4x32_10_engine(rocrand_generator&)
-    threefry4x64_20_engine(rocrand_generator& generator) : m_generator(generator)
+    explicit threefry4x64_20_engine(rocrand_generator& generator) : m_generator(generator)
     {
         if(generator == NULL)
         {
@@ -3599,6 +3619,7 @@ public:
     }
 
     /// \copydoc philox4x32_10_engine::min()
+    // cppcheck-suppress functionStatic
     result_type min() const
     {
         return 0;

--- a/library/include/rocrand/rocrand_mrg31k3p.h
+++ b/library/include/rocrand/rocrand_mrg31k3p.h
@@ -266,7 +266,7 @@ protected:
     }
 
 private:
-    FQUALIFIERS void mod_mat_vec_m1(const unsigned int* A, unsigned int* s)
+    FQUALIFIERS static void mod_mat_vec_m1(const unsigned int* A, unsigned int* s)
     {
         unsigned long long x[3] = {s[0], s[1], s[2]};
 
@@ -277,7 +277,7 @@ private:
         s[2] = mod_m1(mod_m1(A[6] * x[0]) + mod_m1(A[7] * x[1]) + mod_m1(A[8] * x[2]));
     }
 
-    FQUALIFIERS void mod_mat_vec_m2(const unsigned int* A, unsigned int* s)
+    FQUALIFIERS static void mod_mat_vec_m2(const unsigned int* A, unsigned int* s)
     {
         unsigned long long x[3] = {s[0], s[1], s[2]};
 
@@ -288,7 +288,7 @@ private:
         s[2] = mod_m2(mod_m2(A[6] * x[0]) + mod_m2(A[7] * x[1]) + mod_m2(A[8] * x[2]));
     }
 
-    FQUALIFIERS unsigned long long mod_mul_m1(unsigned int i, unsigned long long j)
+    FQUALIFIERS static unsigned long long mod_mul_m1(unsigned int i, unsigned long long j)
     {
         return mod_m1(i * j);
     }
@@ -298,7 +298,7 @@ private:
         return p % ROCRAND_MRG31K3P_M1;
     }
 
-    FQUALIFIERS unsigned long long mod_mul_m2(unsigned int i, unsigned long long j)
+    FQUALIFIERS static unsigned long long mod_mul_m2(unsigned int i, unsigned long long j)
     {
         return mod_m2(i * j);
     }

--- a/library/include/rocrand/rocrand_mrg31k3p.h
+++ b/library/include/rocrand/rocrand_mrg31k3p.h
@@ -293,7 +293,7 @@ private:
         return mod_m1(i * j);
     }
 
-    FQUALIFIERS unsigned long long mod_m1(unsigned long long p)
+    FQUALIFIERS static unsigned long long mod_m1(unsigned long long p)
     {
         return p % ROCRAND_MRG31K3P_M1;
     }
@@ -303,7 +303,7 @@ private:
         return mod_m2(i * j);
     }
 
-    FQUALIFIERS unsigned long long mod_m2(unsigned long long p)
+    FQUALIFIERS static unsigned long long mod_m2(unsigned long long p)
     {
         return p % ROCRAND_MRG31K3P_M2;
     }

--- a/library/include/rocrand/rocrand_mrg32k3a.h
+++ b/library/include/rocrand/rocrand_mrg32k3a.h
@@ -351,7 +351,7 @@ private:
     }
 
     FQUALIFIERS
-    unsigned long long mod_m1(unsigned long long p)
+    static unsigned long long mod_m1(unsigned long long p)
     {
         p = detail::mad_u64_u32(ROCRAND_MRG32K3A_M1C, (p >> 32), p & (ROCRAND_MRG32K3A_POW32 - 1));
         if (p >= ROCRAND_MRG32K3A_M1)
@@ -378,7 +378,7 @@ private:
     }
 
     FQUALIFIERS
-    unsigned long long mod_m2(unsigned long long p)
+    static unsigned long long mod_m2(unsigned long long p)
     {
         p = detail::mad_u64_u32(ROCRAND_MRG32K3A_M2C, (p >> 32), p & (ROCRAND_MRG32K3A_POW32 - 1));
         p = detail::mad_u64_u32(ROCRAND_MRG32K3A_M2C, (p >> 32), p & (ROCRAND_MRG32K3A_POW32 - 1));

--- a/library/include/rocrand/rocrand_mrg32k3a.h
+++ b/library/include/rocrand/rocrand_mrg32k3a.h
@@ -288,7 +288,7 @@ protected:
 
 private:
     FQUALIFIERS
-    void mod_mat_vec_m1(const unsigned long long * A,
+    static void mod_mat_vec_m1(const unsigned long long * A,
                         unsigned int * s)
     {
         unsigned long long x[3];
@@ -311,7 +311,7 @@ private:
     }
 
     FQUALIFIERS
-    void mod_mat_vec_m2(const unsigned long long * A,
+    static void mod_mat_vec_m2(const unsigned long long * A,
                         unsigned int * s)
     {
         unsigned long long x[3];
@@ -334,7 +334,7 @@ private:
     }
 
     FQUALIFIERS
-    unsigned long long mod_mul_m1(unsigned int i,
+    static unsigned long long mod_mul_m1(unsigned int i,
                                   unsigned long long j)
     {
         long long hi, lo, temp1, temp2;
@@ -361,7 +361,7 @@ private:
     }
 
     FQUALIFIERS
-    unsigned long long mod_mul_m2(unsigned int i,
+    static unsigned long long mod_mul_m2(unsigned int i,
                                   unsigned long long j)
     {
         long long hi, lo, temp1, temp2;

--- a/library/include/rocrand/rocrand_mtgp32.h
+++ b/library/include/rocrand/rocrand_mtgp32.h
@@ -159,7 +159,7 @@ public:
     }
 
     FQUALIFIERS
-    mtgp32_engine(const mtgp32_state m_state,
+    mtgp32_engine(const mtgp32_state &m_state,
                   const mtgp32_params * params,
                   int bid)
     {
@@ -287,7 +287,7 @@ public:
 
 private:
     FQUALIFIERS
-    unsigned int para_rec(unsigned int X1, unsigned int X2, unsigned int Y)
+    unsigned int para_rec(unsigned int X1, unsigned int X2, unsigned int Y) const
     {
         unsigned int X = (X1 & mask) ^ X2;
         unsigned int MAT;
@@ -299,7 +299,7 @@ private:
     }
 
     FQUALIFIERS
-    unsigned int temper(unsigned int V, unsigned int T)
+    unsigned int temper(unsigned int V, unsigned int T) const
     {
         unsigned int MAT;
 
@@ -310,7 +310,7 @@ private:
     }
 
     FQUALIFIERS
-    unsigned int temper_single(unsigned int V, unsigned int T)
+    unsigned int temper_single(unsigned int V, unsigned int T) const 
     {
         unsigned int MAT;
         unsigned int r;

--- a/library/include/rocrand/rocrand_mtgp32.h
+++ b/library/include/rocrand/rocrand_mtgp32.h
@@ -153,7 +153,8 @@ class mtgp32_engine
 {
 public:
     FQUALIFIERS
-    mtgp32_engine()
+    // Initialization is not supported for __shared__ variables
+    mtgp32_engine() // cppcheck-suppress uninitMemberVar
     {
 
     }

--- a/library/include/rocrand/rocrand_philox4x32_10.h
+++ b/library/include/rocrand/rocrand_philox4x32_10.h
@@ -312,7 +312,7 @@ protected:
 private:
     // Single Philox4x32 round
     FQUALIFIERS
-    uint4 single_round(uint4 counter, uint2 key)
+    static uint4 single_round(uint4 counter, uint2 key)
     {
         // Source: Random123
         unsigned int hi0;
@@ -328,7 +328,7 @@ private:
     }
 
     FQUALIFIERS
-    uint2 bumpkey(uint2 key)
+    static uint2 bumpkey(uint2 key)
     {
         key.x += ROCRAND_PHILOX_W32_0;
         key.y += ROCRAND_PHILOX_W32_1;

--- a/library/include/rocrand/rocrand_scrambled_sobol32.h
+++ b/library/include/rocrand/rocrand_scrambled_sobol32.h
@@ -36,7 +36,7 @@ class scrambled_sobol32_engine
 {
 public:
     FQUALIFIERS
-    scrambled_sobol32_engine() {}
+    scrambled_sobol32_engine() : scramble_constant() {}
 
     FQUALIFIERS
     scrambled_sobol32_engine(const unsigned int* vectors,

--- a/library/include/rocrand/rocrand_scrambled_sobol64.h
+++ b/library/include/rocrand/rocrand_scrambled_sobol64.h
@@ -36,7 +36,7 @@ class scrambled_sobol64_engine
 {
 public:
     FQUALIFIERS
-    scrambled_sobol64_engine() {}
+    scrambled_sobol64_engine() : scramble_constant() {}
 
     FQUALIFIERS
     scrambled_sobol64_engine(const unsigned long long int* vectors,

--- a/library/include/rocrand/rocrand_sobol32.h
+++ b/library/include/rocrand/rocrand_sobol32.h
@@ -122,7 +122,7 @@ public:
     }
 
     FQUALIFIERS
-    unsigned int current()
+    unsigned int current() const
     {
         return m_state.d;
     }
@@ -137,7 +137,7 @@ protected:
         m_state.d = 0;
         for(int i = 0; i < 32; i++)
         {
-            m_state.d ^= (g & (1 << i) ? m_state.vectors[i] : 0);
+            m_state.d ^= (g & (1U << i) ? m_state.vectors[i] : 0);
         }
     }
 

--- a/library/include/rocrand/rocrand_sobol32.h
+++ b/library/include/rocrand/rocrand_sobol32.h
@@ -37,7 +37,7 @@ struct sobol32_state
     unsigned int vectors[32];
 
     FQUALIFIERS
-    sobol32_state() { }
+    sobol32_state() : d(), i(), vectors() { }
 
     FQUALIFIERS
     sobol32_state(const unsigned int d,
@@ -60,7 +60,7 @@ struct sobol32_state<true>
     const unsigned int * vectors;
 
     FQUALIFIERS
-    sobol32_state() { }
+    sobol32_state() : d(), i(), vectors() { }
 
     FQUALIFIERS
     sobol32_state(const unsigned int d,

--- a/library/include/rocrand/rocrand_sobol64.h
+++ b/library/include/rocrand/rocrand_sobol64.h
@@ -37,7 +37,7 @@ struct sobol64_state
     unsigned long long int vectors[64];
 
     FQUALIFIERS
-    sobol64_state() { }
+    sobol64_state() : d(), i(), vectors() { }
 
     FQUALIFIERS
     sobol64_state(const unsigned long long int d,
@@ -60,7 +60,7 @@ struct sobol64_state<true>
     const unsigned long long int * vectors;
 
     FQUALIFIERS
-    sobol64_state() { }
+    sobol64_state() : d(), i(), vectors() { }
 
     FQUALIFIERS
     sobol64_state(const unsigned long long int d,

--- a/library/include/rocrand/rocrand_sobol64.h
+++ b/library/include/rocrand/rocrand_sobol64.h
@@ -121,7 +121,7 @@ public:
     }
 
     FQUALIFIERS
-    unsigned long long int current()
+    unsigned long long int current() const
     {
         return m_state.d;
     }

--- a/library/include/rocrand/rocrand_threefry2_impl.h
+++ b/library/include/rocrand/rocrand_threefry2_impl.h
@@ -166,7 +166,7 @@ public:
     }
 
 protected:
-    FQUALIFIERS state_value threefry_rounds(state_value counter, state_value key)
+    FQUALIFIERS static state_value threefry_rounds(state_value counter, state_value key)
     {
         state_value X;
         value       ks[2 + 1];

--- a/library/include/rocrand/rocrand_threefry4_impl.h
+++ b/library/include/rocrand/rocrand_threefry4_impl.h
@@ -177,7 +177,7 @@ public:
     }
 
 protected:
-    FQUALIFIERS state_value threefry_rounds(state_value counter, state_value key)
+    FQUALIFIERS static state_value threefry_rounds(state_value counter, state_value key)
     {
         state_value X;
         value       ks[4 + 1];

--- a/library/include/rocrand/rocrand_xorwow.h
+++ b/library/include/rocrand/rocrand_xorwow.h
@@ -59,7 +59,7 @@ void mul_mat_vec_inplace(const unsigned int * m, unsigned int * v)
     {
         const int i = ij / XORWOW_M;
         const int j = ij % XORWOW_M;
-        const unsigned int b = (v[i] & (1 << j)) ? 0xffffffff : 0x0;
+        const unsigned int b = (v[i] & (1U << j)) ? 0xffffffff : 0x0;
         for (int k = 0; k < XORWOW_N; k++)
         {
             r[k] ^= b & m[i * XORWOW_M * XORWOW_N + j * XORWOW_N + k];

--- a/library/src/rng/distribution/discrete.hpp
+++ b/library/src/rng/distribution/discrete.hpp
@@ -52,7 +52,8 @@ public:
     static constexpr unsigned int input_width = 1;
     static constexpr unsigned int output_width = 1;
 
-    rocrand_discrete_distribution_base()
+    // rocrand_discrete_distribution_st is a struct 
+    rocrand_discrete_distribution_base()  // cppcheck-suppress uninitDerivedMemberVar
     {
         size = 0;
         probability = NULL;

--- a/library/src/rng/distribution/discrete.hpp
+++ b/library/src/rng/distribution/discrete.hpp
@@ -195,7 +195,7 @@ protected:
         }
     }
 
-    void normalize(std::vector<double>& p)
+    void normalize(std::vector<double>& p) const
     {
         double sum = 0.0;
         for (unsigned int i = 0; i < size; i++)

--- a/library/src/rng/distribution/log_normal.hpp
+++ b/library/src/rng/distribution/log_normal.hpp
@@ -256,8 +256,8 @@ struct mrg_engine_log_normal_distribution<__half, state_type>
     const __half2 mean;
     const __half2 stddev;
 
-    __host__ __device__ mrg_engine_log_normal_distribution(__half mean, __half stddev)
-        : mean(mean, mean), stddev(stddev, stddev)
+    __host__ __device__ mrg_engine_log_normal_distribution(__half mean, __half stddev) // cppcheck-suppress uninitMemberVar
+        : mean(mean, mean), stddev(stddev, stddev) 
     {}
 
     __host__ __device__

--- a/library/src/rng/distribution/normal.hpp
+++ b/library/src/rng/distribution/normal.hpp
@@ -253,8 +253,8 @@ struct mrg_engine_normal_distribution<__half, state_type>
     const __half2 mean;
     const __half2 stddev;
 
-    __host__ __device__ mrg_engine_normal_distribution(__half mean, __half stddev)
-        : mean(mean, mean), stddev(stddev, stddev)
+    __host__ __device__ mrg_engine_normal_distribution(__half mean, __half stddev) // cppcheck-suppress uninitMemberVar
+        : mean(mean, mean), stddev(stddev, stddev) 
     {}
 
     __host__ __device__

--- a/library/src/rng/distribution/poisson.hpp
+++ b/library/src/rng/distribution/poisson.hpp
@@ -39,7 +39,7 @@ public:
     rocrand_poisson_distribution()
         : base() { }
 
-    rocrand_poisson_distribution(double lambda)
+    explicit rocrand_poisson_distribution(double lambda)
         : rocrand_poisson_distribution()
     {
         set_lambda(lambda);
@@ -158,7 +158,7 @@ struct mrg_engine_poisson_distribution
 
     rocrand_poisson_distribution<ROCRAND_DISCRETE_METHOD_ALIAS> dis;
 
-    mrg_engine_poisson_distribution(rocrand_poisson_distribution<ROCRAND_DISCRETE_METHOD_ALIAS> dis)
+    explicit mrg_engine_poisson_distribution(rocrand_poisson_distribution<ROCRAND_DISCRETE_METHOD_ALIAS> dis)
         : dis(dis)
     { }
 
@@ -180,7 +180,7 @@ struct mrg_engine_poisson_distribution
 
 struct mrg_poisson_distribution : mrg_engine_poisson_distribution<rocrand_state_mrg32k3a>
 {
-    mrg_poisson_distribution(rocrand_poisson_distribution<ROCRAND_DISCRETE_METHOD_ALIAS> dis)
+    explicit mrg_poisson_distribution(rocrand_poisson_distribution<ROCRAND_DISCRETE_METHOD_ALIAS> dis)
         : mrg_engine_poisson_distribution(dis)
     {}
 };

--- a/library/src/rng/lfsr113.hpp
+++ b/library/src/rng/lfsr113.hpp
@@ -150,6 +150,7 @@ public:
         , m_engines_initialized(false)
         , m_engines(NULL)
         , m_engines_size(s_threads * s_blocks)
+        , m_start_engine_id()
     {
         // Allocate device random number engines
         hipError_t error

--- a/library/src/rng/mrg31k3p.hpp
+++ b/library/src/rng/mrg31k3p.hpp
@@ -153,6 +153,7 @@ public:
         , m_engines_initialized(false)
         , m_engines(NULL)
         , m_engines_size(s_threads * s_blocks)
+        , m_start_engine_id()
     {
         // Allocate device random number engines
         hipError_t error

--- a/library/src/rng/mrg32k3a.hpp
+++ b/library/src/rng/mrg32k3a.hpp
@@ -157,6 +157,7 @@ public:
         , m_engines_initialized(false)
         , m_engines(NULL)
         , m_engines_size(s_threads * s_blocks)
+        , m_start_engine_id()
     {
         // Allocate device random number engines
         hipError_t error

--- a/library/src/rng/scrambled_sobol32.hpp
+++ b/library/src/rng/scrambled_sobol32.hpp
@@ -157,7 +157,7 @@ public:
     rocrand_scrambled_sobol32(unsigned long long offset = 0,
                               rocrand_ordering   order  = ROCRAND_ORDERING_QUASI_DEFAULT,
                               hipStream_t        stream = 0)
-        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1)
+        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1), m_current_offset()
     {
         // Allocate direction vectors
         hipError_t error;
@@ -340,7 +340,7 @@ private:
 
     // m_offset from base_type
 
-    size_t next_power2(size_t x)
+    static size_t next_power2(size_t x)
     {
         size_t power = 1;
         while(power < x)

--- a/library/src/rng/scrambled_sobol64.hpp
+++ b/library/src/rng/scrambled_sobol64.hpp
@@ -157,7 +157,7 @@ public:
     rocrand_scrambled_sobol64(unsigned long long offset = 0,
                               rocrand_ordering   order  = ROCRAND_ORDERING_QUASI_DEFAULT,
                               hipStream_t        stream = 0)
-        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1)
+        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1), m_current_offset()
     {
         // Allocate direction vectors
         hipError_t error;
@@ -341,7 +341,7 @@ private:
 
     // m_offset from base_type
 
-    size_t next_power2(size_t x)
+    static size_t next_power2(size_t x)
     {
         size_t power = 1;
         while(power < x)

--- a/library/src/rng/sobol32.hpp
+++ b/library/src/rng/sobol32.hpp
@@ -152,7 +152,7 @@ public:
     rocrand_sobol32(unsigned long long offset = 0,
                     rocrand_ordering   order  = ROCRAND_ORDERING_QUASI_DEFAULT,
                     hipStream_t        stream = 0)
-        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1)
+        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1), m_current_offset()
     {
         // Allocate direction vectors
         hipError_t error;
@@ -315,7 +315,7 @@ private:
 
     // m_offset from base_type
 
-    size_t next_power2(size_t x)
+    static size_t next_power2(size_t x)
     {
         size_t power = 1;
         while (power < x)

--- a/library/src/rng/sobol64.hpp
+++ b/library/src/rng/sobol64.hpp
@@ -153,7 +153,7 @@ public:
     rocrand_sobol64(unsigned long long int offset = 0,
                     rocrand_ordering       order  = ROCRAND_ORDERING_QUASI_DEFAULT,
                     hipStream_t            stream = 0)
-        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1)
+        : base_type(order, 0, offset, stream), m_initialized(false), m_dimensions(1), m_current_offset()
     {
         // Allocate direction vectors
         hipError_t error;
@@ -317,7 +317,7 @@ private:
 
     // m_offset from base_type
 
-    size_t next_power2(size_t x)
+    size_t static next_power2(size_t x)
     {
         size_t power = 1;
         while (power < x)

--- a/library/src/rng/xorwow.hpp
+++ b/library/src/rng/xorwow.hpp
@@ -156,6 +156,7 @@ public:
         , m_engines_initialized(false)
         , m_engines(NULL)
         , m_engines_size(s_threads * s_blocks)
+        , m_start_engine_id()
     {
         // Allocate device random number engines
         auto error

--- a/tools/sobol32_direction_vector_generator.cpp
+++ b/tools/sobol32_direction_vector_generator.cpp
@@ -148,7 +148,7 @@ int main(int argc, char const *argv[])
     uint32_t SOBOL_DIM = 20000;
     uint32_t SOBOL32_N = SOBOL_DIM * 32;
     struct sobol_set * inputs = new struct sobol_set[SOBOL_DIM];
-    uint32_t * directions_32 = new uint32_t[SOBOL32_N];
+    uint32_t * directions_32 = new uint32_t[SOBOL32_N]();
     bool read = read_sobol_set(inputs, SOBOL_DIM, vector_file);
 
     if (read)

--- a/tools/sobol64_direction_vector_generator.cpp
+++ b/tools/sobol64_direction_vector_generator.cpp
@@ -148,7 +148,7 @@ int main(int argc, char const *argv[])
     uint32_t SOBOL_DIM = 20000;
     uint32_t SOBOL64_N = SOBOL_DIM * 64;
     struct sobol_set * inputs = new struct sobol_set[SOBOL_DIM];
-    uint64_t * directions_64 = new uint64_t[SOBOL64_N];
+    uint64_t * directions_64 = new uint64_t[SOBOL64_N]();
     bool read = read_sobol_set(inputs, SOBOL_DIM, vector_file);
 
     if (read)

--- a/tools/xorwow_precomputed_generator.cpp
+++ b/tools/xorwow_precomputed_generator.cpp
@@ -41,7 +41,7 @@ void mul_mat_vec_inplace(const unsigned int * m, unsigned int * v)
     {
         for (int j = 0; j < XORWOW_M; j++)
         {
-            if (v[i] & (1 << j))
+            if (v[i] & (1U << j))
             {
                 for (int k = 0; k < XORWOW_N; k++)
                 {
@@ -121,7 +121,7 @@ void generate_matrices()
         for (int j = 0; j < XORWOW_M; j++)
         {
             rocrand_xorwow_state state;
-            const unsigned int b = 1 << j;
+            const unsigned int b = 1U << j;
             for (int k = 0; k < XORWOW_N; k++)
             {
                 state.x[k] = (i == k ? b : 0);


### PR DESCRIPTION
This PR fixes some Cppcheck reported issues:

. Modified some functions to be static because they only access static member and do not need access a class instance.
. Added some data members to the constructor initializer list.
. Removed some warnings for exceptThrowInDestructor since the destructor is using noexcept(false).
. Removed some warnings for uninitMemberVar because some initializations are not supported.
