### PR TITLE
cherry pick hot fixes from 5.7

### DIFF
--- a/benchmark/benchmark_rocrand_kernel.cpp
+++ b/benchmark/benchmark_rocrand_kernel.cpp
@@ -88,16 +88,7 @@ void generate_kernel(GeneratorState * states,
                      const Extra extra)
 {
     const unsigned int state_id = blockIdx.x * blockDim.x + threadIdx.x;
-
-    // Using gridDim.x * blockDim.x should actually a performance improvement, however, this kernel
-    // just so happen to use an unfortunate amount of registers that the changes introduced in
-    // https://github.com/llvm/llvm-project/commit/ba0d079c7aa52bc0ae860d16dd4a33b0dc5cfff7,
-    // cause adverse code generation that degrades performance.
-#ifdef USE_HIP_CPU
-    const unsigned int stride = gridDim.x * blockDim.x;
-#else
-    const unsigned int stride = hipGridDim_x * hipBlockDim_x;
-#endif
+    const unsigned int stride   = gridDim.x * blockDim.x;
 
     GeneratorState state = states[state_id];
     unsigned int index = state_id;


### PR DESCRIPTION
* Enable gfx94x build targets (#353)



---------




* 5.7 cherry pick - Benchmark perf. improvements for discrete distributions (#379)

* Remove workaround with hipGridDim_x * hipBlockDim_x

It makes no difference anymore on ROCm >= 5.5, probably after switching to code object v5.

* Use restrict with tables of discrete distributions

This change improves performance in device API benchamrks for most engines.

---------



---------