### PR TITLE
Hard coded path (/opt/rocm-version) references removed from cmake files

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -145,11 +145,15 @@ rocm_install(
 )
 
 set(FORTRAN_SRCS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/rocrand/src/fortran")
-configure_file(
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(CONFIG_PACKAGE_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/rocrand)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
     src/rocrand-fortran-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/rocrand-fortran-config.cmake
+    INSTALL_DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR}
 )
-
 
 if(USE_HIP_CPU)
     rocm_export_targets(

--- a/library/src/rocrand-fortran-config.cmake.in
+++ b/library/src/rocrand-fortran-config.cmake.in
@@ -66,11 +66,12 @@
 #    // Link bar against HIP or CUDA library (see hipconfig)
 #    target_link_libraries(bar roc::rocrand)
 #
+@PACKAGE_INIT@
 
 # Fortran wrapper
 if(@BUILD_FORTRAN_WRAPPER@)
-    set_and_check(rocrand_FORTRAN_SRC_DIR "@FORTRAN_SRCS_INSTALL_DIR@")
-    set_and_check(rocrand_FORTRAN_SRC_DIRS "@FORTRAN_SRCS_INSTALL_DIR@")
+    set_and_check(rocrand_FORTRAN_SRC_DIR  "${PACKAGE_PREFIX_DIR}/rocrand/src/fortran")
+    set_and_check(rocrand_FORTRAN_SRC_DIRS "${PACKAGE_PREFIX_DIR}/rocrand/src/fortran")
     set(rocrand_FORTRAN_FOUND YES)
 else()
     set(rocrand_FORTRAN_FOUND NOTFOUND)


### PR DESCRIPTION
Changes Proposed
- Hard coded path reference removed from fortran config cmake files.
- resolves issue 426645