### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "ci:docs-only"
+    reviewers:
+      - "samjwu"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,9 +10,9 @@ formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/.sphinx/requirements.txt
+   - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To build documentation locally, use the following code:
 cd docs
 
 # Install Python dependencies
-python3 -m pip install -r .sphinx/requirements.txt
+python3 -m pip install -r sphinx/requirements.txt
 
 # Build the documentation
 python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
 /_build/
 /_doxygen/
-/.doxygen/docBin/
-/.doxygen/*.tag
-/.sphinx/_toc.yml
+/doxygen/html/
+/doxygen/xml/
+/doxygen/*.tag
+/sphinx/_toc.yml

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,2 +1,0 @@
-rocm-docs-core>=0.20.0
-numpy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,11 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-from rocm_docs import ROCmDocs
 import pathlib
+import re
 import sys
+
+from rocm_docs import ROCmDocs
 
 # We need to add the location of the rocrand Python module to the PATH
 # in order to build the documentation of that module
@@ -14,11 +16,27 @@ docs_dir_path = pathlib.Path(__file__).parent
 python_dir_path = docs_dir_path.parent / 'python' / 'rocrand'
 sys.path.append(str(python_dir_path))
 
-external_projects_current_project = "rocrand"
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'rocm_setup_version\( VERSION\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"rocRAND {version_number} Documentation"
 
-docs_core = ROCmDocs("rocRAND Documentation")
-docs_core.run_doxygen()
+# for PDF output on Read the Docs
+project = "rocRAND Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+external_toc_path = "./sphinx/_toc.yml"
+
+docs_core = ROCmDocs(left_nav_title)
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
+
+external_projects_current_project = "rocrand"
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -823,9 +823,6 @@ INPUT                  = ../mainpage.dox \
                          ../rocrandhost.dox \
                          ../rocranddevice.dox \
                          ../rocrandhostcpp.dox \
-                         ../hiprandhost.dox \
-                         ../hipranddevice.dox \
-                         ../hiprandhostcpp.dox \
                          ../../library/include/rocrand
 
 # This tag can be used to specify the character encoding of the source files

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE.txt

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -7,3 +7,6 @@ subtrees:
     - file: programmers_guide
     - file: cpp_api
     - file: python_api
+  - caption: About
+    entries:
+    - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,2 @@
+rocm-docs-core==0.30.3
+numpy

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -86,9 +86,7 @@ pygments==2.15.1
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2023.3.post1


### PR DESCRIPTION
Apply the following changes to project documentation for ReadtheDocs:

add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
remove docBin from URL
update rocm-docs-core dependency
update dependabot config

Relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330