### PR TITLE
Switch from using hipcc to using Clang compiler

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -20,7 +20,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 # gfxTargetParser reads gfxarch and adds target features such as xnack
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${buildStatic} ${amdgpuTargets} ${codeCovFlag} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ../..
+                ${cmake} --toolchain=toolchain-linux.cmake ${buildTypeArg} ${buildStatic} ${amdgpuTargets} ${codeCovFlag} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ../..
                 make -j\$(nproc)
                 """
 
@@ -93,4 +93,3 @@ def runCodeCovTestCommand(platform, project, jobName)
 }
 
 return this
-

--- a/install
+++ b/install
@@ -146,7 +146,8 @@ fi
 # before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the HIPCC compiler.
 #
 
-compiler="hipcc"
+compiler="amdclang++"
+cmake_common_options="${cmake_common_options} --toolchain=toolchain-linux.cmake"
 
 cmake_executable="cmake"
 

--- a/install
+++ b/install
@@ -142,11 +142,10 @@ fi
 #   BUILD_BENCHMARK - off by default.
 #
 # ! IMPORTANT !
-# On ROCm platform set C++ compiler to HIPCC. You can do it by adding 'CXX=<path-to-hipcc>'
-# before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the HIPCC compiler.
+# On ROCm platform set C++ compiler to clang++ >= 17. You can do it by adding 'CXX=<path-to-clang>'
+# before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the clang++ compiler.
 #
 
-compiler="amdclang++"
 cmake_common_options="${cmake_common_options} --toolchain=toolchain-linux.cmake"
 
 cmake_executable="cmake"
@@ -170,7 +169,7 @@ else
 fi
 
 if [[ "${build_relocatable}" == true ]]; then
-    CXX=${rocm_path}/bin/$compiler ${cmake_executable}  -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
+    ${cmake_executable}  -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
     -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ${cmake_common_options} \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip" \
     -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
@@ -178,7 +177,7 @@ if [[ "${build_relocatable}" == true ]]; then
     -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip;${rocm_path}/hip/cmake" \
     ../../. # or cmake-gui ../.
 else
-    CXX=${rocm_path}/bin/$compiler ${cmake_executable} ${clients} ${cmake_common_options} ../../. # or cmake-gui ../.
+    ${cmake_executable} ${clients} ${cmake_common_options} ../../. # or cmake-gui ../.
 fi
 check_exit_code "$?"
 

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -12,6 +12,5 @@ endif()
 
 # set(CMAKE_CXX_COMPILER "hipcc")
 # set(CMAKE_C_COMPILER "hipcc")
-set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")
-set(CMAKE_C_COMPILER "${rocm_bin}/hipcc")
-
+set(CMAKE_CXX_COMPILER "${rocm_bin}/amdclang++")
+set(CMAKE_C_COMPILER "${rocm_bin}/amdclang")

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -5,12 +5,12 @@
 
 if (DEFINED ENV{ROCM_PATH})
   set(rocm_bin "$ENV{ROCM_PATH}/bin")
+  set(llvm_bin "$ENV{ROCM_PATH}/llvm/bin")
 else()
   set(rocm_bin "/opt/rocm/bin")
+  set(llvm_bin "/opt/rocm/llvm/bin")
 endif()
 
 
-# set(CMAKE_CXX_COMPILER "hipcc")
-# set(CMAKE_C_COMPILER "hipcc")
-set(CMAKE_CXX_COMPILER "${rocm_bin}/amdclang++")
-set(CMAKE_C_COMPILER "${rocm_bin}/amdclang")
+set(CMAKE_CXX_COMPILER "${llvm_bin}/clang++")
+set(CMAKE_C_COMPILER "${llvm_bin}/clang")

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -5,12 +5,19 @@
 
 if (DEFINED ENV{ROCM_PATH})
   set(rocm_bin "$ENV{ROCM_PATH}/bin")
-  set(llvm_bin "$ENV{ROCM_PATH}/llvm/bin")
 else()
+  set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to the ROCm installation.")
   set(rocm_bin "/opt/rocm/bin")
-  set(llvm_bin "/opt/rocm/llvm/bin")
 endif()
 
+if (NOT DEFINED ENV{CXX})
+  set(CMAKE_CXX_COMPILER "${rocm_bin}/amdclang++")
+else()
+  set(CMAKE_CXX_COMPILER "$ENV{CXX}")
+endif()
 
-set(CMAKE_CXX_COMPILER "${llvm_bin}/clang++")
-set(CMAKE_C_COMPILER "${llvm_bin}/clang")
+if (NOT DEFINED ENV{CC})
+  set(CMAKE_C_COMPILER "${rocm_bin}/amdclang")
+else()
+  set(CMAKE_C_COMPILER "$ENV{CC}")
+endif()


### PR DESCRIPTION
As hipcc is a thin wrapper around clang, we're trying to move away from using it to reduce complexity.