### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
+# Global owners
+* @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13
+
 # Documentation files
 docs/* @saadrahim @LisaDelaney
 *.md  @saadrahim @LisaDelaney
 *.rst  @saadrahim @LisaDelaney
+
 # Header directory
-library/include/*  @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13 @saadrahim @LisaDelaney
+library/include/*  @saadrahim @LisaDelaney


### PR DESCRIPTION
Fixed a typo.
I think "@stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13" were meant to be global owners.