### PR TITLE
Update codeowners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 * @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13
 
 # Documentation files
-docs/* @saadrahim @LisaDelaney
-*.md  @saadrahim @LisaDelaney
-*.rst  @saadrahim @LisaDelaney
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation
 
 # Header directory
-library/include/*  @saadrahim @LisaDelaney
+library/include/* @ROCm/rocm-documentation @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2833
Adding documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.