### PR TITLE
cmake: link tools to stdc++fs library if necessary

### DIFF
--- a/test/internal/test_cpp_utils.cpp
+++ b/test/internal/test_cpp_utils.cpp
@@ -57,7 +57,7 @@ TEST(rocrand_cpp_utils_tests, numeric_combinations)
 
     ASSERT_EQ(combinations.size(), A.size() * B.size() * C.size());
 
-    const std::set combination_set(combinations.begin(), combinations.end());
+    const std::set<std::array<int,3>> combination_set(combinations.begin(), combinations.end());
     ASSERT_EQ(combinations.size(), combination_set.size()) << "Not all items are unique";
 
     for(auto [a, b, c] : combinations)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -22,11 +22,29 @@
 
 set(CMAKE_CXX_STANDARD 17)
 
+include(CheckCXXSourceCompiles)
+
+set(HAVE_STD_FILESYSTEM_TEST [[
+  #include <filesystem>
+
+  int main()
+  {
+  std::filesystem::path p{"/"};
+  return 0;
+  }
+  ]])
+check_cxx_source_compiles("${HAVE_STD_FILESYSTEM_TEST}" HAVE_STD_FILESYSTEM)
+
 add_custom_target(tools)
 
 function(rocrand_add_tool TARGET_NAME)
     add_executable(${TARGET_NAME} ${ARGN})
     add_dependencies(tools ${TARGET_NAME})
+    if(NOT HAVE_STD_FILESYSTEM)
+      # if filesystem library is not available in the standard library,
+      # link to the separate library instead
+      target_link_options( ${TARGET_NAME} PRIVATE -lstdc++fs )
+    endif()
 endfunction()
 
 rocrand_add_tool(bin2typed bin2typed.cpp)

--- a/tools/bin2typed.cpp
+++ b/tools/bin2typed.cpp
@@ -20,7 +20,6 @@
 
 #include "utils.hpp"
 
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <ios>

--- a/tools/scrambled_sobol32_direction_vector_generator.cpp
+++ b/tools/scrambled_sobol32_direction_vector_generator.cpp
@@ -21,7 +21,6 @@
 #include "sobol_utils.hpp"
 #include "utils.hpp"
 
-#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iostream>

--- a/tools/scrambled_sobol64_direction_vector_generator.cpp
+++ b/tools/scrambled_sobol64_direction_vector_generator.cpp
@@ -21,7 +21,6 @@
 #include "sobol_utils.hpp"
 #include "utils.hpp"
 
-#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iostream>

--- a/tools/sobol32_direction_vector_generator.cpp
+++ b/tools/sobol32_direction_vector_generator.cpp
@@ -21,7 +21,6 @@
 #include "sobol_utils.hpp"
 #include "utils.hpp"
 
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string_view>

--- a/tools/sobol_utils.hpp
+++ b/tools/sobol_utils.hpp
@@ -21,7 +21,16 @@
 #ifndef ROCRAND_TOOLS_SOBOL_UTILS_HPP_
 #define ROCRAND_TOOLS_SOBOL_UTILS_HPP_
 
+#if __has_include(<filesystem>)
 #include <filesystem>
+#else
+#include <experimental/filesystem>
+namespace std
+{
+    namespace filesystem = experimental::filesystem;
+}
+#endif
+
 #include <fstream>
 #include <iostream>
 

--- a/tools/utils.hpp
+++ b/tools/utils.hpp
@@ -21,7 +21,16 @@
 #ifndef ROCRAND_TOOLS_UTILS_HPP_
 #define ROCRAND_TOOLS_UTILS_HPP_
 
+#if __has_include(<filesystem>)
 #include <filesystem>
+#else
+#include <experimental/filesystem>
+namespace std
+{
+    namespace filesystem = experimental::filesystem;
+}
+#endif
+
 #include <fstream>
 #include <string_view>
 


### PR DESCRIPTION
Fixes RHEL 8 build which is old enough to have std::filesystem stuff in a separate library.