### PR TITLE
Add hip::host to roc::rocrand interface libraries

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -120,6 +120,7 @@ if(HIP_COMPILER STREQUAL "nvcc")
     set(CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
 else()
     target_link_libraries(rocrand PRIVATE hip::device)
+    target_link_libraries(rocrand PUBLIC hip::host)
 endif()
 
 if(NOT WIN32)


### PR DESCRIPTION
The HIP headers are included in rocrand.h and the HIP library should therefore be included in the roc::rocrand interface libraries.