### PR TITLE
Fix regression due to change in code generation

### DIFF
--- a/library/src/rng/sobol.hpp
+++ b/library/src/rng/sobol.hpp
@@ -46,6 +46,21 @@
 namespace rocrand_host::detail
 {
 
+template<bool Scrambled, class Engine, class Constant>
+__host__ __device__ Engine create_engine(const Constant*           vectors,
+                                         [[maybe_unused]] Constant scramble_constant,
+                                         const unsigned int        offset)
+{
+    if constexpr(Scrambled)
+    {
+        return Engine(vectors, scramble_constant, offset);
+    }
+    else
+    {
+        return Engine(vectors, offset);
+    }
+};
+
 template<unsigned int OutputPerThread,
          bool         Scrambled,
          class Engine,
@@ -105,19 +120,6 @@ __host__ __device__ void generate_sobol(dim3               block_idx,
     }();
 
     const Constant scramble_constant = Scrambled ? scramble_constants[dimension] : 0;
-    const auto     create_engine
-        = [scramble_constant](const Constant* vectors, const unsigned int offset)
-    {
-        if constexpr(Scrambled)
-        {
-            return Engine(vectors, scramble_constant, offset);
-        }
-        else
-        {
-            (void)scramble_constant;
-            return Engine(vectors, offset);
-        }
-    };
 
     data += dimension * n;
 
@@ -130,7 +132,9 @@ __host__ __device__ void generate_sobol(dim3               block_idx,
     if constexpr(output_per_thread == 1)
     {
         const unsigned int engine_offset = engine_id * output_per_thread;
-        Engine             engine        = create_engine(vectors_ptr, offset + engine_offset);
+        Engine             engine        = create_engine<Scrambled, Engine>(vectors_ptr,
+                                                         scramble_constant,
+                                                         offset + engine_offset);
 
         while(index < n)
         {
@@ -150,7 +154,9 @@ __host__ __device__ void generate_sobol(dim3               block_idx,
         const unsigned int engine_offset
             = engine_id * output_per_thread
               + (engine_id == 0 ? 0 : head_size); // The first engine writes head_size values
-        Engine engine = create_engine(vectors_ptr, offset + engine_offset);
+        Engine engine = create_engine<Scrambled, Engine>(vectors_ptr,
+                                                         scramble_constant,
+                                                         offset + engine_offset);
 
         if(engine_id == 0)
         {


### PR DESCRIPTION
Among other things, https://github.com/ROCm/rocRAND/pull/404 refactors the Sobol generator. A part of this refactor replaces a freestanding function by a lambda. Since the compiler optimizes freestanding functions and lambdas slightly differently, this results in different generated code. The changes in generated code result in different performance characteristics of this kernel, for some architectures, getting worse performance in some cases. This PR changes the kernel in a non-functional way, to restore the old performance characteristics and to undo this regression.