### PR TITLE
Fix use of undefined member m_engine_size (#513).

### DIFF
--- a/library/src/rng/xorwow.hpp
+++ b/library/src/rng/xorwow.hpp
@@ -201,7 +201,7 @@ public:
         m_engines_initialized          = other.m_engines_initialized;
         m_engines                      = other.m_engines;
         m_start_engine_id              = other.m_start_engine_id;
-        m_engines_size                 = other.m_engine_size;
+        m_engines_size                 = other.m_engines_size;
         m_seed                         = other.m_seed;
         m_poisson                      = std::move(other.m_poisson);
 


### PR DESCRIPTION
Fix https://github.com/ROCm/rocRAND/issues/513 .