### PR TITLE
Improve null test coverage

### DIFF
--- a/test/test_rocrand_generate.cpp
+++ b/test/test_rocrand_generate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -146,13 +146,21 @@ TEST_P(rocrand_generate_tests, short_test)
 TEST(rocrand_generate_tests, neg_test)
 {
     const size_t size = 256;
-    unsigned int * data = NULL;
+    void*        data = nullptr;
 
-    rocrand_generator generator = NULL;
-    EXPECT_EQ(
-        rocrand_generate(generator, (unsigned int *) data, size),
-        ROCRAND_STATUS_NOT_CREATED
-    );
+    rocrand_generator generator = nullptr;
+
+    EXPECT_EQ(rocrand_generate(generator, static_cast<unsigned int*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_char(generator, static_cast<unsigned char*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_short(generator, static_cast<unsigned short*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_long_long(generator, static_cast<unsigned long long*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
 }
 
 INSTANTIATE_TEST_SUITE_P(rocrand_generate_tests,

--- a/test/test_rocrand_generate_log_normal.cpp
+++ b/test/test_rocrand_generate_log_normal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -151,16 +151,26 @@ TEST_P(rocrand_generate_log_normal_tests, half_test)
 
 TEST(rocrand_generate_log_normal_tests, neg_test)
 {
-    const size_t size = 256;
-    float mean = 5.0;
-    float stddev = 2.0;
-    float * data = NULL;
+    const size_t size   = 256;
+    float        mean   = 5.0;
+    float        stddev = 2.0;
+    void*        data   = nullptr;
 
-    rocrand_generator generator = NULL;
+    rocrand_generator generator = nullptr;
+
+    EXPECT_EQ(rocrand_generate_log_normal(generator, static_cast<float*>(data), size, mean, stddev),
+              ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_log_normal_double(generator,
+                                                 static_cast<double*>(data),
+                                                 size,
+                                                 mean,
+                                                 stddev),
+              ROCRAND_STATUS_NOT_CREATED);
+
     EXPECT_EQ(
-        rocrand_generate_log_normal(generator, (float *) data, size, mean, stddev),
-        ROCRAND_STATUS_NOT_CREATED
-    );
+        rocrand_generate_log_normal_half(generator, static_cast<half*>(data), size, mean, stddev),
+        ROCRAND_STATUS_NOT_CREATED);
 }
 
 INSTANTIATE_TEST_SUITE_P(rocrand_generate_log_normal_tests,

--- a/test/test_rocrand_generate_normal.cpp
+++ b/test/test_rocrand_generate_normal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -151,16 +151,22 @@ TEST_P(rocrand_generate_normal_tests, half_test)
 
 TEST(rocrand_generate_normal_tests, neg_test)
 {
-    const size_t size = 256;
-    float mean = 5.0;
-    float stddev = 2.0;
-    float * data = NULL;
+    const size_t size   = 256;
+    float        mean   = 5.0;
+    float        stddev = 2.0;
+    void*        data   = nullptr;
 
-    rocrand_generator generator = NULL;
+    rocrand_generator generator = nullptr;
+
+    EXPECT_EQ(rocrand_generate_normal(generator, static_cast<float*>(data), size, mean, stddev),
+              ROCRAND_STATUS_NOT_CREATED);
+
     EXPECT_EQ(
-        rocrand_generate_normal(generator, (float *) data, size, mean, stddev),
-        ROCRAND_STATUS_NOT_CREATED
-    );
+        rocrand_generate_normal_double(generator, static_cast<double*>(data), size, mean, stddev),
+        ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_normal_half(generator, static_cast<half*>(data), size, mean, stddev),
+              ROCRAND_STATUS_NOT_CREATED);
 }
 
 INSTANTIATE_TEST_SUITE_P(rocrand_generate_normal_tests,

--- a/test/test_rocrand_generate_poisson.cpp
+++ b/test/test_rocrand_generate_poisson.cpp
@@ -79,15 +79,14 @@ TEST_P(rocrand_generate_poisson_tests, generate_test)
 
 TEST(rocrand_generate_poisson_tests, neg_test)
 {
-    const size_t size = 256;
-    double         lambda = 100.0;
-    unsigned int * data = NULL;
+    const size_t size   = 256;
+    double       lambda = 100.0;
+    void*        data   = nullptr;
 
-    rocrand_generator generator = NULL;
-    EXPECT_EQ(
-        rocrand_generate_poisson(generator, (unsigned int *)data, size, lambda),
-        ROCRAND_STATUS_NOT_CREATED
-    );
+    rocrand_generator generator = nullptr;
+
+    EXPECT_EQ(rocrand_generate_poisson(generator, static_cast<unsigned int*>(data), size, lambda),
+              ROCRAND_STATUS_NOT_CREATED);
 }
 
 TEST_P(rocrand_generate_poisson_tests, out_of_range_test)

--- a/test/test_rocrand_generate_uniform.cpp
+++ b/test/test_rocrand_generate_uniform.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -146,13 +146,18 @@ TEST_P(rocrand_generate_uniform_tests, half_test)
 TEST(rocrand_generate_uniform_tests, neg_test)
 {
     const size_t size = 256;
-    float * data = NULL;
+    void*        data = nullptr;
 
-    rocrand_generator generator = NULL;
-    EXPECT_EQ(
-        rocrand_generate_uniform(generator, (float *) data, size),
-        ROCRAND_STATUS_NOT_CREATED
-    );
+    rocrand_generator generator = nullptr;
+
+    EXPECT_EQ(rocrand_generate_uniform(generator, static_cast<float*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_uniform_double(generator, static_cast<double*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
+
+    EXPECT_EQ(rocrand_generate_uniform_half(generator, static_cast<half*>(data), size),
+              ROCRAND_STATUS_NOT_CREATED);
 }
 
 INSTANTIATE_TEST_SUITE_P(rocrand_generate_uniform_tests,


### PR DESCRIPTION
This PR improve the coverage of the `neg_test` by also testing more `generate_*` functions.