### PR TITLE
HOTFIX: Correct CMake for TBB dependency

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -130,9 +130,9 @@ if(NOT WIN32 AND ROCRAND_USE_TBB)
         message(WARNING "TBB is not found. Building without parallel STL support")
     else()
         target_link_libraries(rocrand PRIVATE TBB::tbb)
-        rocm_package_add_deb_dependencies("libtbb-dev")
-        set(CPACK_DEB_PACKAGE_REQUIRES "${CPACK_DEB_PACKAGE_REQUIRES}" PARENT_SCOPE)
-        rocm_package_add_rpm_dependencies("(tbb-devel or tbb)")
+        rocm_package_add_deb_dependencies(DEPENDS "libtbb-dev")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDSS "${CPACK_DEBIAN_PACKAGE_DEPENDSS}" PARENT_SCOPE)
+        rocm_package_add_rpm_dependencies(DEPENDS "(tbb-devel or tbb)")
         set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES}" PARENT_SCOPE)
 
         # Older libstdc++ headers require TBB to be installed to be able to #include <execution>

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -131,7 +131,7 @@ if(NOT WIN32 AND ROCRAND_USE_TBB)
     else()
         target_link_libraries(rocrand PRIVATE TBB::tbb)
         rocm_package_add_deb_dependencies(DEPENDS "libtbb-dev")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDSS "${CPACK_DEBIAN_PACKAGE_DEPENDSS}" PARENT_SCOPE)
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}" PARENT_SCOPE)
         rocm_package_add_rpm_dependencies(DEPENDS "(tbb-devel or tbb)")
         set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES}" PARENT_SCOPE)
 


### PR DESCRIPTION
Previously the CMake code used the incorrect variable for the Debian dependencies, and had incorrect syntax for the `rocm_package_add_*_dependencies` calls.