### PR TITLE
Clarify HIP usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,8 @@ if(GPU_TARGETS STREQUAL "all")
   set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)
 endif()
 
-if(NOT WIN32)
-  include(cmake/VerifyCompiler.cmake)
-else()
-  list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} $ENV{ROCM_PATH}/hip $ENV{ROCM_PATH}/llvm)
-  find_package(hip REQUIRED CONFIG PATHS ${HIP_DIR} $ENV{ROCM_PATH})
-endif()
+# Verify the compiler settings and include the HIP CMake package
+include(cmake/VerifyCompiler.cmake)
 
 # Build option to disable -Werror
 option(DISABLE_WERROR "Disable building with Werror" ON)

--- a/cmake/VerifyCompiler.cmake
+++ b/cmake/VerifyCompiler.cmake
@@ -20,22 +20,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} $ENV{ROCM_PATH}/hip)
+list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} $ENV{ROCM_PATH}/hip $ENV{ROCM_PATH})
 if(CMAKE_CXX_COMPILER MATCHES ".*/nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    find_package(hip QUIET CONFIG PATHS $ENV{ROCM_PATH})
-    if(NOT hip_FOUND)
-        find_package(HIP REQUIRED)
-    endif()
+    # Compiling for CUDA
+    find_package(hip REQUIRED CONFIG PATHS $ENV{ROCM_PATH})
     if((HIP_COMPILER STREQUAL "clang"))
        # TODO: The HIP package on NVIDIA platform is incorrect at few versions
        set(HIP_COMPILER "nvcc" CACHE STRING "HIP Compiler" FORCE)
     endif()
 else()
-  message("Looking in $ENV{ROCM_PATH}...")
-  find_package(hip REQUIRED CONFIG PATHS $ENV{ROCM_PATH})
+    # compiling for ROCm
+    message("Looking in $ENV{ROCM_PATH}...")
+    find_package(hip REQUIRED CONFIG PATHS $ENV{ROCM_PATH})
 endif()
 
 if(HIP_COMPILER STREQUAL "nvcc")
+    # NVCC requires some additional setup
     include(SetupNVCC)
 elseif(HIP_COMPILER STREQUAL "clang")
     if(NOT (CMAKE_CXX_COMPILER MATCHES ".*hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+"))


### PR DESCRIPTION
The Windows pathway should no longer require special treatment, so we can simplify by moving everything into VerifyCompiler.cmake. Additionally, we shouldn't need to support the use of the HIP CMake package as a module, config should be sufficient. Also added some comments to clarify what is going on.