### PR TITLE
Move data type support file along with index and ToC changes

### DIFF
--- a/docs/api-reference/data-type-support.rst
+++ b/docs/api-reference/data-type-support.rst
@@ -4,7 +4,7 @@
 
 .. _data-type-support:
 
-Data type support
+rocRAND data type support
 ******************************************
 
 Host API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,12 +31,13 @@ The documentation is structured as follows:
   .. grid-item-card:: Conceptual
 
     * :ref:`programmers-guide`
-    * :ref:`data-type-support`
+
     * :ref:`curand-compatibility`
     * :ref:`dynamic-ordering-configuration`
 
   .. grid-item-card:: API reference
 
+    * :doc:`rocRAND data type support <api-reference/data-type-support>`
     * :ref:`cpp-api`
     * :ref:`python-api`
     * :doc:`Fortran API reference <fortran-api-reference>`

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -8,11 +8,11 @@ subtrees:
   - caption: Conceptual
     entries:
     - file: conceptual/programmers-guide
-    - file: conceptual/data-type-support
     - file: conceptual/curand-compatibility
     - file: conceptual/dynamic_ordering_configuration
   - caption: API reference
     entries:
+    - file: api-reference/data-type-support
     - file: api-reference/cpp-api
     - file: api-reference/python-api
     - file: fortran-api-reference


### PR DESCRIPTION
Moving the data type support file requires additional changes and PRs in hipRAND and ROCm/ROCm to point to the correct location. I will update this PR when those PRs are available.

I will eventually backport this back to docs/6.2.0 for consistency.