### PR TITLE
Move data type support file along with index and ToC changes 6.2 version

### DIFF
--- a/docs/api-reference/data-type-support.rst
+++ b/docs/api-reference/data-type-support.rst
@@ -1,4 +1,10 @@
-Data type support
+.. meta::
+   :description: rocRAND documentation and API reference library
+   :keywords: rocRAND, ROCm, API, documentation, cuRAND
+
+.. _data-type-support:
+
+rocRAND data type support
 ******************************************
 
 Host API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ The documentation is structured as follows:
 
   .. grid-item-card:: API reference
 
+    * :doc:`rocRAND data type support <api-reference/data-type-support>`
     * :ref:`cpp-api`
     * :ref:`python-api`
     * :doc:`API library <doxygen/html/index>`

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -12,6 +12,7 @@ subtrees:
     - file: conceptual/dynamic_ordering_configuration
   - caption: API reference
     entries:
+    - file: api-reference/data-type-support
     - file: api-reference/cpp-api
     - file: api-reference/python-api
     - file: doxygen/html/index


### PR DESCRIPTION
This is based on https://github.com/ROCm/rocRAND/pull/548, but is not a cherry pick. Due to the differences in files between 6.3 and 6.2 and the difficulties of implementing a merge, I reimplemented the required changes. I will use this as a template to cherry-pick to docs/6.2.1 and docs/6.2.0.

There was no meta-data in this version of the file, so I added the contents from the develop version of the file, along with a missing reference tag.