### PR TITLE
Fixed memory leaks in rocrand_tests

### DIFF
--- a/test/internal/test_rocrand_config_dispatch.cpp
+++ b/test/internal/test_rocrand_config_dispatch.cpp
@@ -89,6 +89,8 @@ TEST(rocrand_config_dispatch_tests, host_matches_device)
 
     ASSERT_NE(host_arch, rocrand_impl::host::target_arch::invalid);
     ASSERT_EQ(host_arch, device_arch);
+
+    HIP_CHECK(hipFree(device_arch_ptr));
 }
 
 TEST(rocrand_config_dispatch_tests, parse_common_architectures)

--- a/test/test_rocrand_cpp_basic.cpp
+++ b/test/test_rocrand_cpp_basic.cpp
@@ -84,8 +84,9 @@ TYPED_TEST(rocrand_cpp_basic_tests, move_construction)
 
     float actual;
     HIP_CHECK(hipMemcpy(&actual, d_data, sizeof(actual), hipMemcpyDeviceToHost));
-
     ASSERT_EQ(expected, actual);
+    
+    HIP_CHECK(hipFree(d_data));
 }
 
 TYPED_TEST(rocrand_cpp_basic_tests, move_assignment)
@@ -119,6 +120,7 @@ TYPED_TEST(rocrand_cpp_basic_tests, move_assignment)
 
     float actual;
     HIP_CHECK(hipMemcpy(&actual, d_data, sizeof(actual), hipMemcpyDeviceToHost));
-
     ASSERT_EQ(expected, actual);
+    
+    HIP_CHECK(hipFree(d_data));
 }

--- a/test/test_rocrand_hipgraphs.cpp
+++ b/test/test_rocrand_hipgraphs.cpp
@@ -34,34 +34,33 @@ void test_float(std::function<rocrand_status(rocrand_generator, float*, size_t, 
     HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
     rocrand_set_stream(generator, stream);
 
-    hipGraphExec_t graph_instance;
-    hipGraph_t graph = test_utils::createGraphHelper(stream);
+    test_utils::GraphHelper gHelper;
 
     // Any sizes
     ROCRAND_CHECK(
         generate_fn(generator, data, 1, mean, stddev)
     );
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-    test_utils::resetGraphHelper(graph, graph_instance, stream);
+    gHelper.createGraph(stream, true, true, true);
+    gHelper.resetGraphHelper(stream);
 
     // Any alignment
     ROCRAND_CHECK(
         generate_fn(generator, data+1, 2, mean, stddev)
     );
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-    test_utils::resetGraphHelper(graph, graph_instance, stream);
+    gHelper.createGraph(stream, true, true, true);
+    gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(
         generate_fn(generator, data, size, mean, stddev)
     );
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+    gHelper.createGraph(stream, true, true, true);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
-    test_utils::cleanupGraphHelper(graph, graph_instance);
+    gHelper.cleanupGraphHelper();
     HIP_CHECK(hipStreamDestroy(stream));
 }
 
@@ -109,34 +108,33 @@ TEST_P(rocrand_hipgraph_generate_tests, uniform_float_test)
     HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
     rocrand_set_stream(generator, stream);
     
-    hipGraphExec_t graph_instance;
-    hipGraph_t graph = test_utils::createGraphHelper(stream);
+    test_utils::GraphHelper gHelper;
 
     // Any sizes
     ROCRAND_CHECK(
         rocrand_generate_uniform(generator, data, 1)
     );
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-    test_utils::resetGraphHelper(graph, graph_instance, stream);
+    gHelper.createGraph(stream, true, true, true);
+    gHelper.resetGraphHelper(stream);
 
     // Any alignment
     ROCRAND_CHECK(
         rocrand_generate_uniform(generator, data+1, 2)
     );
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-    test_utils::resetGraphHelper(graph, graph_instance, stream);
+    gHelper.createGraph(stream, true, true, true);
+    gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(
         rocrand_generate_uniform(generator, data, size)
     );
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+    gHelper.createGraph(stream, true, true, true);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
-    test_utils::cleanupGraphHelper(graph, graph_instance);
+    gHelper.cleanupGraphHelper();
     HIP_CHECK(hipStreamDestroy(stream));
 }
 
@@ -159,28 +157,27 @@ TEST_P(rocrand_hipgraph_generate_tests, poisson_test)
     HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
     rocrand_set_stream(generator, stream);
 
-    hipGraphExec_t graph_instance;
-    hipGraph_t     graph = test_utils::createGraphHelper(stream);
+    test_utils::GraphHelper gHelper;
 
     // Any sizes
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data, 1, 10.0));
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-    test_utils::resetGraphHelper(graph, graph_instance, stream);
+    gHelper.createGraph(stream, true, true, true);
+    gHelper.resetGraphHelper(stream);
 
     // Any alignment
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data + 1, 2, 500.0));
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-    test_utils::resetGraphHelper(graph, graph_instance, stream);
+    gHelper.createGraph(stream, true, true, true);
+    gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data, size, 5000.0));
 
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+    gHelper.createGraph(stream, true, true, true);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
-    test_utils::cleanupGraphHelper(graph, graph_instance);
+    gHelper.cleanupGraphHelper();
     HIP_CHECK(hipStreamDestroy(stream));
 }
 

--- a/test/test_rocrand_hipgraphs.cpp
+++ b/test/test_rocrand_hipgraphs.cpp
@@ -36,12 +36,13 @@ void test_float(std::function<rocrand_status(rocrand_generator, float*, size_t, 
 
     test_utils::GraphHelper gHelper;
 
+    gHelper.startStreamCapture(stream);
+
     // Any sizes
     ROCRAND_CHECK(
         generate_fn(generator, data, 1, mean, stddev)
     );
-
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
     gHelper.resetGraphHelper(stream);
 
     // Any alignment
@@ -49,14 +50,14 @@ void test_float(std::function<rocrand_status(rocrand_generator, float*, size_t, 
         generate_fn(generator, data+1, 2, mean, stddev)
     );
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
     gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(
         generate_fn(generator, data, size, mean, stddev)
     );
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
@@ -109,13 +110,14 @@ TEST_P(rocrand_hipgraph_generate_tests, uniform_float_test)
     rocrand_set_stream(generator, stream);
     
     test_utils::GraphHelper gHelper;
+    gHelper.startStreamCapture(stream);
 
     // Any sizes
     ROCRAND_CHECK(
         rocrand_generate_uniform(generator, data, 1)
     );
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
     gHelper.resetGraphHelper(stream);
 
     // Any alignment
@@ -123,14 +125,14 @@ TEST_P(rocrand_hipgraph_generate_tests, uniform_float_test)
         rocrand_generate_uniform(generator, data+1, 2)
     );
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
     gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(
         rocrand_generate_uniform(generator, data, size)
     );
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
@@ -158,22 +160,23 @@ TEST_P(rocrand_hipgraph_generate_tests, poisson_test)
     rocrand_set_stream(generator, stream);
 
     test_utils::GraphHelper gHelper;
+    gHelper.startStreamCapture(stream);
 
     // Any sizes
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data, 1, 10.0));
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
     gHelper.resetGraphHelper(stream);
 
     // Any alignment
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data + 1, 2, 500.0));
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
     gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data, size, 5000.0));
 
-    gHelper.createGraph(stream, true, true, true);
+    gHelper.createAndLaunchGraph(stream, true, true);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));

--- a/test/test_rocrand_hipgraphs.cpp
+++ b/test/test_rocrand_hipgraphs.cpp
@@ -42,7 +42,7 @@ void test_float(std::function<rocrand_status(rocrand_generator, float*, size_t, 
     ROCRAND_CHECK(
         generate_fn(generator, data, 1, mean, stddev)
     );
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
     gHelper.resetGraphHelper(stream);
 
     // Any alignment
@@ -50,14 +50,14 @@ void test_float(std::function<rocrand_status(rocrand_generator, float*, size_t, 
         generate_fn(generator, data+1, 2, mean, stddev)
     );
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
     gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(
         generate_fn(generator, data, size, mean, stddev)
     );
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
@@ -117,7 +117,7 @@ TEST_P(rocrand_hipgraph_generate_tests, uniform_float_test)
         rocrand_generate_uniform(generator, data, 1)
     );
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
     gHelper.resetGraphHelper(stream);
 
     // Any alignment
@@ -125,14 +125,14 @@ TEST_P(rocrand_hipgraph_generate_tests, uniform_float_test)
         rocrand_generate_uniform(generator, data+1, 2)
     );
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
     gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(
         rocrand_generate_uniform(generator, data, size)
     );
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
@@ -165,18 +165,18 @@ TEST_P(rocrand_hipgraph_generate_tests, poisson_test)
     // Any sizes
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data, 1, 10.0));
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
     gHelper.resetGraphHelper(stream);
 
     // Any alignment
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data + 1, 2, 500.0));
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
     gHelper.resetGraphHelper(stream);
 
     ROCRAND_CHECK(rocrand_generate_poisson(generator, data, size, 5000.0));
 
-    gHelper.createAndLaunchGraph(stream, true, true);
+    gHelper.createAndLaunchGraph(stream);
 
     HIP_CHECK(hipFree(data));
     ROCRAND_CHECK(rocrand_destroy_generator(generator));

--- a/test/test_rocrand_hipgraphs.cpp
+++ b/test/test_rocrand_hipgraphs.cpp
@@ -43,7 +43,7 @@ void test_float(std::function<rocrand_status(rocrand_generator, float*, size_t, 
         generate_fn(generator, data, 1, mean, stddev)
     );
     gHelper.createAndLaunchGraph(stream);
-    gHelper.resetGraphHelper(stream);
+    gHelper.resetGraphHelper(stream); 
 
     // Any alignment
     ROCRAND_CHECK(

--- a/test/test_utils_hipgraphs.hpp
+++ b/test/test_utils_hipgraphs.hpp
@@ -73,8 +73,6 @@ namespace test_utils
 
                 if(beginCapture)
                     startStreamCapture(stream);
-
-                createAndLaunchGraph(stream);
             }
 
             inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)

--- a/test/test_utils_hipgraphs.hpp
+++ b/test/test_utils_hipgraphs.hpp
@@ -33,13 +33,17 @@ namespace test_utils
             hipGraph_t graph;
             hipGraphExec_t graph_instance;
         public:
-            void createGraph(hipStream_t & stream, const bool beginCapture = true, const bool launchGraph=false, const bool sync=false){
-                if (beginCapture)
-                    HIP_CHECK_NON_VOID(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
-                
-                // End the capture
-                HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
 
+            inline void startStreamCapture(hipStream_t & stream){
+                HIP_CHECK_NON_VOID(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+            }
+
+            inline void endStreamCapture(hipStream_t & stream){
+                HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
+            }
+
+            inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=false, const bool sync=false){
+                
                 HIP_CHECK_NON_VOID(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
 
                 // Optionally launch the graph
@@ -62,8 +66,10 @@ namespace test_utils
                 // Destroy the old graph and instance
                 cleanupGraphHelper();
 
-                // Create a new graph and optionally begin capture
-                createGraph(stream, beginCapture);
+                if(beginCapture)
+                    startStreamCapture(stream);
+
+                createAndLaunchGraph(stream, true, true);
             }
 
             inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)

--- a/test/test_utils_hipgraphs.hpp
+++ b/test/test_utils_hipgraphs.hpp
@@ -42,7 +42,7 @@ namespace test_utils
                 HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
             }
 
-            inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=false, const bool sync=false){
+            inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true){
                 
                 HIP_CHECK_NON_VOID(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
 
@@ -69,7 +69,7 @@ namespace test_utils
                 if(beginCapture)
                     startStreamCapture(stream);
 
-                createAndLaunchGraph(stream, true, true);
+                createAndLaunchGraph(stream);
             }
 
             inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)

--- a/test/test_utils_hipgraphs.hpp
+++ b/test/test_utils_hipgraphs.hpp
@@ -34,15 +34,18 @@ namespace test_utils
             hipGraphExec_t graph_instance;
         public:
 
-            inline void startStreamCapture(hipStream_t & stream){
+            inline void startStreamCapture(hipStream_t & stream)
+            {
                 HIP_CHECK_NON_VOID(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
             }
 
-            inline void endStreamCapture(hipStream_t & stream){
+            inline void endStreamCapture(hipStream_t & stream)
+            {
                 HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
             }
 
-            inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true){
+            inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true)
+            {
                 
                 endStreamCapture(stream);
                 

--- a/test/test_utils_hipgraphs.hpp
+++ b/test/test_utils_hipgraphs.hpp
@@ -44,6 +44,8 @@ namespace test_utils
 
             inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true){
                 
+                endStreamCapture(stream);
+                
                 HIP_CHECK_NON_VOID(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
 
                 // Optionally launch the graph

--- a/test/test_utils_hipgraphs.hpp
+++ b/test/test_utils_hipgraphs.hpp
@@ -28,64 +28,53 @@
 // Note: graphs will not work on the default stream.
 namespace test_utils
 {
+    class GraphHelper{
+        private:
+            hipGraph_t graph;
+            hipGraphExec_t graph_instance;
+        public:
+            void createGraph(hipStream_t & stream, const bool beginCapture = true, const bool launchGraph=false, const bool sync=false){
+                if (beginCapture)
+                    HIP_CHECK_NON_VOID(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+                
+                // End the capture
+                HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
+
+                HIP_CHECK_NON_VOID(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
+
+                // Optionally launch the graph
+                if (launchGraph)
+                    HIP_CHECK_NON_VOID(hipGraphLaunch(graph_instance, stream));
+
+                // Optionally synchronize the stream when we're done
+                if (sync)
+                    HIP_CHECK_NON_VOID(hipStreamSynchronize(stream));
+            } 
     
-    inline hipGraph_t createGraphHelper(hipStream_t& stream, const bool beginCapture=true)
-    {
-        // Create a new graph
-        hipGraph_t graph;
-        HIP_CHECK_NON_VOID(hipGraphCreate(&graph, 0));
+            inline void cleanupGraphHelper()
+            {
+                HIP_CHECK_NON_VOID(hipGraphDestroy(this->graph));
+                HIP_CHECK_NON_VOID(hipGraphExecDestroy(this->graph_instance));
+            }
 
-        // Optionally begin stream capture
-        if (beginCapture)
-            HIP_CHECK_NON_VOID(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+            inline void resetGraphHelper(hipStream_t& stream, const bool beginCapture=true)
+            {
+                // Destroy the old graph and instance
+                cleanupGraphHelper();
 
-        return graph;
-    }
+                // Create a new graph and optionally begin capture
+                createGraph(stream, beginCapture);
+            }
 
-    inline void cleanupGraphHelper(hipGraph_t& graph, hipGraphExec_t& instance)
-    {
-        HIP_CHECK_NON_VOID(hipGraphDestroy(graph));
-        HIP_CHECK_NON_VOID(hipGraphExecDestroy(instance));
-    }
+            inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)
+            {
+                HIP_CHECK_NON_VOID(hipGraphLaunch(this->graph_instance, stream));
 
-    inline void resetGraphHelper(hipGraph_t& graph, hipGraphExec_t& instance, hipStream_t& stream, const bool beginCapture=true)
-    {
-        // Destroy the old graph and instance
-        cleanupGraphHelper(graph, instance);
-
-        // Create a new graph and optionally begin capture
-        graph = createGraphHelper(stream, beginCapture);
-    }
-
-    inline hipGraphExec_t endCaptureGraphHelper(hipGraph_t& graph, hipStream_t& stream, const bool launchGraph=false, const bool sync=false)
-    {
-        // End the capture
-        HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
-
-        // Instantiate the graph
-        hipGraphExec_t instance;
-        HIP_CHECK_NON_VOID(hipGraphInstantiate(&instance, graph, nullptr, nullptr, 0));
-
-        // Optionally launch the graph
-        if (launchGraph)
-            HIP_CHECK_NON_VOID(hipGraphLaunch(instance, stream));
-
-        // Optionally synchronize the stream when we're done
-        if (sync)
-            HIP_CHECK_NON_VOID(hipStreamSynchronize(stream));
-
-        return instance;
-    }
-
-    inline void launchGraphHelper(hipGraphExec_t& instance, hipStream_t& stream, const bool sync=false)
-    {
-        HIP_CHECK_NON_VOID(hipGraphLaunch(instance, stream));
-
-        // Optionally sync after the launch
-        if (sync)
-            HIP_CHECK_NON_VOID(hipStreamSynchronize(stream));
-    }
-
+                // Optionally sync after the launch
+                if (sync)
+                    HIP_CHECK_NON_VOID(hipStreamSynchronize(stream));
+            }
+    };
 } // end namespace test_utils
 
 #endif //ROCRAND_TEST_UTILS_HIPGRAPHS_HPP


### PR DESCRIPTION
Added missing hipFree calls to test_rocrand_config_dispatch and test_rocrand_cpp_basic. Fixed an issue where test_utils was calling an extra hipCreateGraph call  causing a graph to be overwritten which led to a memory leak.