### PR TITLE
[Doc] Cherry pick - Bump rocm-docs-core[api_reference] to 1.8.2 in /docs/sphinx (#555)

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,2 +1,2 @@
-rocm-docs-core[api_reference]==1.4.0
+rocm-docs-core[api_reference]==1.8.2
 numpy

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -114,7 +114,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api-reference]==1.4.0
+rocm-docs-core[api-reference]==1.8.2
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb


### PR DESCRIPTION
Includes updates for rocm-docs-core to keep header version number current for the "latest" version of the doc build