### PR TITLE
Add readme and metadata info and clarify CUDA references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ split into a separate library. As of version 6.0, hipRAND can no longer be built
 
 ## Documentation
 
-Documentation for rocRAND is available at
-[https://rocm.docs.amd.com/projects/rocRAND/en/latest/](https://rocm.docs.amd.com/projects/rocRAND/en/latest/)
+> [!NOTE]
+> The published rocRAND documentation is available at [rocRAND](https://rocm.docs.amd.com/projects/rocRAND/en/latest/) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the rocRAND/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
 
 To build documentation locally, use the following code:
 

--- a/docs/conceptual/curand-compatibility.rst
+++ b/docs/conceptual/curand-compatibility.rst
@@ -8,7 +8,7 @@
 cuRAND compatibility
 ====================
 
-The following table shows which rocRAND generators produce the exact same sequence as the equivalent cuRAND generator when using legacy ordering, given the same seed, number of dimensions, and offset.
+The following table shows which rocRAND generators produce the exact same sequence as the equivalent NVIDIA CUDA cuRAND generator when using legacy ordering, given the same seed, number of dimensions, and offset.
 
 .. table:: cuRAND Compatibility
     :widths: auto

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,10 +10,10 @@ rocRAND documentation
 
 rocRAND provides functions that generate pseudo-random and quasi-random numbers. The rocRAND library is implemented in the `HIP <https://rocm.docs.amd.com/projects/HIP/en/latest/index.html>`_
 programming language and optimized for AMD's latest discrete GPUs. It is designed to run on top
-of AMD's `ROCm <https://rocm.docs.amd.com/en/latest/>`_, but it also works on CUDA-enabled GPUs.
+of AMD's `ROCm <https://rocm.docs.amd.com/en/latest/>`_, but it also works on NVIDIA CUDA-enabled GPUs.
 
 rocRAND includes a wrapper library called hipRAND, which you can use to easily port
-CUDA applications using the cuRAND library to the
+NVIDIA CUDA applications using the CUDA cuRAND library to the
 `HIP <https://rocm.docs.amd.com/projects/HIP/en/latest/index.html>`_ layer. In the
 `ROCm <https://rocm.docs.amd.com/en/latest/>`_ environment, hipRAND uses rocRAND.
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,3 +1,7 @@
+.. meta::
+  :description: rocRAND licensing information
+  :keywords: rocRAND, ROCm, API, documentation, license
+
 License
 =======
 


### PR DESCRIPTION
This PR makes the following changes:
-- Adds our standard "official docs" disclaimer to the README doc
-- Adds metadata to the license file
-- Adds NVIDIA CUDA or CUDA to cuRAND references