### PR TITLE
Static CI: Add amdclang++ path to cmake prefix path

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -11,6 +11,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     String buildStatic = staticLibrary ? '-DBUILD_SHARED_LIBS=OFF' : '-DBUILD_SHARED_LIBS=ON'
     String codeCovFlag = codeCoverage ? '-DCODE_COVERAGE=ON' : ''
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
+    String cmakePrefixPath = '-DCMAKE_PREFIX_PATH=/opt/rocm/bin'
     //Set CI node's gfx arch as target if PR, otherwise use default targets of the library
     String amdgpuTargets = env.BRANCH_NAME.startsWith('PR-') ? '-DAMDGPU_TARGETS=\$gfx_arch' : ''
 
@@ -20,7 +21,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 # gfxTargetParser reads gfxarch and adds target features such as xnack
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} --toolchain=toolchain-linux.cmake ${buildTypeArg} ${buildStatic} ${amdgpuTargets} ${codeCovFlag} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ../..
+                ${cmake} --toolchain=toolchain-linux.cmake ${cmakePrefixPath} ${buildTypeArg} ${buildStatic} ${amdgpuTargets} ${codeCovFlag} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ../..
                 make -j\$(nproc)
                 """
 

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -11,7 +11,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     String buildStatic = staticLibrary ? '-DBUILD_SHARED_LIBS=OFF' : '-DBUILD_SHARED_LIBS=ON'
     String codeCovFlag = codeCoverage ? '-DCODE_COVERAGE=ON' : ''
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
-    String cmakePrefixPath = '-DCMAKE_PREFIX_PATH=/opt/rocm;/opt/rocm/llvm;/opt/rocm/bin'
+    String cmakePrefixPath = '-DCMAKE_PREFIX_PATH="/opt/rocm;/opt/rocm/llvm;/opt/rocm/bin"'
     //Set CI node's gfx arch as target if PR, otherwise use default targets of the library
     String amdgpuTargets = env.BRANCH_NAME.startsWith('PR-') ? '-DAMDGPU_TARGETS=\$gfx_arch' : ''
 

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -11,7 +11,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     String buildStatic = staticLibrary ? '-DBUILD_SHARED_LIBS=OFF' : '-DBUILD_SHARED_LIBS=ON'
     String codeCovFlag = codeCoverage ? '-DCODE_COVERAGE=ON' : ''
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
-    String cmakePrefixPath = '-DCMAKE_PREFIX_PATH=/opt/rocm/bin'
+    String cmakePrefixPath = '-DCMAKE_PREFIX_PATH=/opt/rocm;/opt/rocm/llvm;/opt/rocm/bin'
     //Set CI node's gfx arch as target if PR, otherwise use default targets of the library
     String amdgpuTargets = env.BRANCH_NAME.startsWith('PR-') ? '-DAMDGPU_TARGETS=\$gfx_arch' : ''
 


### PR DESCRIPTION
passing run http://math-ci.amd.com/job/static-libraries/job/static-build/job/rocRAND/view/change-requests/job/PR-582/4/pipeline-graph/
