### PR TITLE
Fix codeowner syntax for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 * @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13
 
 # Documentation files
-docs/* @ROCm/rocm-documentation
+docs/ @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation
 *.rst @ROCm/rocm-documentation
 
 # Header directory
-library/include/* @ROCm/rocm-documentation @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13
+library/include/ @ROCm/rocm-documentation @stanleytsang-amd @umfranzw @RobsonRLemos @lawruble13


### PR DESCRIPTION
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com
```