### PR TITLE
[rocRAND] fast forwarding rocm-rel-6.5 to head of develop

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -28,7 +28,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     platform.runCommand(this, command)
 }
 
-def runTestCommand (platform, project)
+def runTestCommand (platform, project, boolean rocmExamples=false)
 {
     String sudo = auxiliary.sudo(platform.jenkinsLabel)
     // String centos = platform.jenkinsLabel.contains('centos') ? '3' : ''
@@ -44,6 +44,34 @@ def runTestCommand (platform, project)
             """
 
     platform.runCommand(this, command)
+    //ROCM Examples
+    if (rocmExamples){
+        String buildString = ""
+        if (platform.os.contains("ubuntu")){
+            buildString += "sudo dpkg -i *.deb"
+        }
+        else {
+            buildString += "sudo rpm -i *.rpm"
+        }
+        testCommand = """#!/usr/bin/env bash
+                    set -ex
+                    cd ${project.paths.project_build_prefix}/build/release/package
+                    ${buildString}
+                    cd ../../..
+                    testDirs=("Libraries/rocRAND")
+                    git clone https://github.com/ROCm/rocm-examples.git
+                    rocm_examples_dir=\$(readlink -f rocm-examples)
+                    for testDir in \${testDirs[@]}; do
+                        cd \${rocm_examples_dir}/\${testDir}
+                        cmake -S . -B build
+                        cmake --build build
+                        cd ./build
+                        ctest --output-on-failure
+                    done
+                """
+        platform.runCommand(this, testCommand, "ROCM Examples")  
+
+    }
 }
 
 def runPackageCommand(platform, project)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -29,7 +29,7 @@ def runCI =
     {
         platform, project->
 
-        commonGroovy.runTestCommand(platform, project)
+        commonGroovy.runTestCommand(platform, project, true)
     }
 
     def packageCommand =

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -59,63 +59,9 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Global flag to cause add_library() to crea
 # HIP dependency is handled earlier in the project cmake file
 # when VerifyCompiler.cmake is included.
 
-# For downloading and building required dependencies
-include(FetchContent)
-
 # Fortran Wrapper
 if(BUILD_FORTRAN_WRAPPER)
     enable_language(Fortran)
-endif()
-
-# Test dependencies
-if(BUILD_TEST)
-  # Google Test (https://github.com/google/googletest)
-  # NOTE: Google Test has created a mess with legacy FindGTest.cmake and newer GTestConfig.cmake
-  #
-  # FindGTest.cmake defines:   GTest::GTest, GTest::Main, GTEST_FOUND
-  #
-  # GTestConfig.cmake defines: GTest::gtest, GTest::gtest_main, GTest::gmock, GTest::gmock_main
-  #
-  # NOTE2: Finding GTest in MODULE mode, one cannot invoke find_package in CONFIG mode, because targets
-  #        will be duplicately defined.
-  if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
-    find_package(GTest QUIET)
-  endif()
-
-  if(NOT TARGET GTest::GTest AND NOT TARGET GTest::gtest)
-    message(STATUS "Google Test not found or force download on. Fetching...")
-    option(BUILD_GTEST "Builds the googletest subproject" ON)
-    option(BUILD_GMOCK "Builds the googlemock subproject" OFF)
-    option(INSTALL_GTEST "Enable installation of googletest" OFF)
-    FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        v1.15.2
-    )
-    FetchContent_MakeAvailable(googletest)
-  endif()
-endif()
-
-# Benchmark dependencies
-if(BUILD_BENCHMARK)
-  # Google Benchmark (https://github.com/google/benchmark)
-  if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
-    find_package(benchmark 1.9.1 QUIET)
-  endif()
-
-  if(NOT TARGET benchmark::benchmark)
-    message(STATUS "Google Benchmark not found or force download on. Fetching...")
-    option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library" OFF)
-    option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark" OFF)
-    FetchContent_Declare(
-      googlebenchmark
-      GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG        v1.9.1
-    )
-    set(HAVE_STD_REGEX ON)
-    set(RUN_HAVE_STD_REGEX 1)
-    FetchContent_MakeAvailable(googlebenchmark)
-  endif()
 endif()
 
 set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
@@ -175,3 +121,56 @@ include(ROCMCheckTargetIds)
 include(ROCMUtilities)
 include(ROCMClients)
 include(ROCMHeaderWrapper)
+
+# For downloading and building required dependencies
+include(FetchContent)
+# Test dependencies
+if(BUILD_TEST)
+  # Google Test (https://github.com/google/googletest)
+  # NOTE: Google Test has created a mess with legacy FindGTest.cmake and newer GTestConfig.cmake
+  #
+  # FindGTest.cmake defines:   GTest::GTest, GTest::Main, GTEST_FOUND
+  #
+  # GTestConfig.cmake defines: GTest::gtest, GTest::gtest_main, GTest::gmock, GTest::gmock_main
+  #
+  # NOTE2: Finding GTest in MODULE mode, one cannot invoke find_package in CONFIG mode, because targets
+  #        will be duplicately defined.
+  if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
+    find_package(GTest QUIET)
+  endif()
+
+  if(NOT TARGET GTest::GTest AND NOT TARGET GTest::gtest)
+    message(STATUS "Google Test not found or force download on. Fetching...")
+    option(BUILD_GTEST "Builds the googletest subproject" ON)
+    option(BUILD_GMOCK "Builds the googlemock subproject" OFF)
+    option(INSTALL_GTEST "Enable installation of googletest" OFF)
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG        v1.15.2
+    )
+    FetchContent_MakeAvailable(googletest)
+  endif()
+endif()
+
+# Benchmark dependencies
+if(BUILD_BENCHMARK)
+  # Google Benchmark (https://github.com/google/benchmark)
+  if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
+    find_package(benchmark 1.9.1 QUIET)
+  endif()
+
+  if(NOT TARGET benchmark::benchmark)
+    message(STATUS "Google Benchmark not found or force download on. Fetching...")
+    option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library" OFF)
+    option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark" OFF)
+    FetchContent_Declare(
+      googlebenchmark
+      GIT_REPOSITORY https://github.com/google/benchmark.git
+      GIT_TAG        v1.9.1
+    )
+    set(HAVE_STD_REGEX ON)
+    set(RUN_HAVE_STD_REGEX 1)
+    FetchContent_MakeAvailable(googlebenchmark)
+  endif()
+endif()

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -41,7 +41,7 @@ click-log==0.4.0
     # via doxysphinx
 comm==0.2.2
     # via ipykernel
-cryptography==43.0.1
+cryptography==44.0.1
     # via pyjwt
 debugpy==1.8.12
     # via ipykernel


### PR DESCRIPTION
* Added ROCM-Examples
* Rearranged include ordering in Dependencies.cmake so that CMAKE_INSTALL_LIBDIR will be lib on RHEL8
