### PR TITLE
Fix broken link to hipfort in fortran-api autogen doc

### DIFF
--- a/library/src/fortran/README.md
+++ b/library/src/fortran/README.md
@@ -8,7 +8,7 @@ refer to the C Host API functions documentation.
 
 ## Deprecation notice
 
-This library is currently deprecated in favor of [hipfort](https://github/ROCm/hipfort).
+This library is currently deprecated in favor of [hipfort](https://github.com/ROCm/hipfort).
 
 ## Build and install
 


### PR DESCRIPTION
Fix broken link to hipfort GitHub in file that is used to auto-generate fortran-api-reference.md