### PR TITLE
Revert "made the default for install benchmark ON (#630)"

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -163,7 +163,7 @@ if(BUILD_BENCHMARK)
   if(NOT TARGET benchmark::benchmark)
     message(STATUS "Google Benchmark not found or force download on. Fetching...")
     option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library" OFF)
-    option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark" ON)
+    option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark" OFF)
     FetchContent_Declare(
       googlebenchmark
       GIT_REPOSITORY https://github.com/google/benchmark.git


### PR DESCRIPTION
This reverts commit 952332e10a3bcf0825a8382a2e0e0d477b4670bf.  It is causing linking issues with Pytorch's benchmarks.