### PR TITLE
Move restore user global state code to proper section

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -103,15 +103,6 @@ if(NOT ROCM_FOUND)
   find_package(ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR} NO_DEFAULT_PATH)
 endif()
 
-# Restore user global state
-set(CMAKE_CXX_FLAGS ${USER_CXX_FLAGS})
-if(DEFINED USER_BUILD_SHARED_LIBS)
-  set(BUILD_SHARED_LIBS ${USER_BUILD_SHARED_LIBS})
-else()
-  unset(BUILD_SHARED_LIBS CACHE )
-endif()
-set(ROCM_WARN_TOOLCHAIN_VAR ${USER_ROCM_WARN_TOOLCHAIN_VAR} CACHE BOOL "")
-
 include(ROCMSetupVersion)
 include(ROCMCreatePackage)
 include(ROCMInstallTargets)
@@ -174,3 +165,12 @@ if(BUILD_BENCHMARK)
     FetchContent_MakeAvailable(googlebenchmark)
   endif()
 endif()
+
+# Restore user global state
+set(CMAKE_CXX_FLAGS ${USER_CXX_FLAGS})
+if(DEFINED USER_BUILD_SHARED_LIBS)
+  set(BUILD_SHARED_LIBS ${USER_BUILD_SHARED_LIBS})
+else()
+  unset(BUILD_SHARED_LIBS CACHE )
+endif()
+set(ROCM_WARN_TOOLCHAIN_VAR ${USER_ROCM_WARN_TOOLCHAIN_VAR} CACHE BOOL "")


### PR DESCRIPTION
I believe #624 was incomplete in that it did not move the restore user global state code https://github.com/ROCm/rocRAND/blob/9203a70993c3dc876eb0d45055082ab12fa58e39/cmake/Dependencies.cmake#L160
to after the configuration of googletest and googlebenchmark.

This results in the tests and benchmarks to be built as shared libraries by default and not static libraries (which is how it worked before).  This then requires googletest/bench libs to be installed on the system, which is not guaranteed and is causing issues in QA testing. 

@NguyenNhuDi Please confirm if the location of the restore user global state code was intended by your PR.
