### PR TITLE
Phase 2 of the rocRAND docs refresh

### DIFF
--- a/docs/api-reference/cpp-api.rst
+++ b/docs/api-reference/cpp-api.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: rocRAND documentation and API reference library
-  :keywords: rocRAND, ROCm, API, documentation
+  :description: rocRAND C/C++ API reference
+  :keywords: rocRAND, ROCm, API, documentation, C, C++
 
 .. _cpp-api:
 
@@ -13,12 +13,13 @@ This chapter describes the rocRAND C and C++ API.
 API index
 =========
 
-To search an API, refer to the API :ref:`genindex`.
+To search the API, refer to the API :ref:`genindex`.
 
 Device functions
 ================
 
-To use the device API, include the file ``rocrand_kernel.h`` in files that define kernels that use rocRAND device functions. The typical usage of device functions consists of the following operations in the device kernel definition:
+To use the device API, include the file ``rocrand_kernel.h`` in files that define kernels that use rocRAND device functions. 
+Follow these steps to use the device functions in the device kernel definition:
 
 1. Create a new generator state object of the desired generator type.
 
@@ -28,9 +29,10 @@ To use the device API, include the file ``rocrand_kernel.h`` in files that defin
 
 4. Use the results.
 
-Since the rocRAND device functions are invoked from inside the user kernel, the generated numbers can be used right away in the kernel without the need to copy them to the host memory.
+The rocRAND device functions are invoked from inside the user kernel.
+This means the generated numbers can be used right away in the kernel without the need to copy them to the host memory.
 
-In the below example, random number generation is using the XORWOW generator.
+In the following example, random number generation uses the XORWOW generator.
 
 ..  code-block:: cpp
 
@@ -62,7 +64,9 @@ In the below example, random number generation is using the XORWOW generator.
 C host API
 ==========
 
-The C host API allows encapsulation of the internal generator state. Random numbers may be produced either on the host or device, depending on the created generator object. The typical sequence of operations for device generation consists of the following steps:
+The C host API allows encapsulation of the internal generator state.
+Random numbers can be produced either on the host or device, depending on the created generator object.
+The typical sequence of operations for device generation consists of the following steps:
 
 1. Allocate memory on the device with ``hipMalloc``.
 
@@ -76,9 +80,12 @@ The C host API allows encapsulation of the internal generator state. Random numb
 
 6. Clean up with ``rocrand_destroy_generator`` and ``hipFree``.
 
-To generate random numbers on the host, the memory allocation in step one should be made using a host memory allocation call. In step two ``rocrand_create_generator_host`` should be called instead. In the last step, the appropriate memory release should be made using the ``rocrand_destroy_generator``. All other calls work identically whether you are generating random numbers on the device or on the host CPU. 
+To generate random numbers on the host, allocate the memory in the first step
+using a host memory allocation call. In step two, call ``rocrand_create_generator_host`` instead.
+In the last step, release the appropriate memory using ``rocrand_destroy_generator``.
+All other calls work identically whether you are generating random numbers on the device or on the host CPU. 
 
-In the example below, the C host API is used to generate 10 random floats using GPU capabilities.
+The example below uses the C host API to generate ten random floats using GPU capabilities.
 
 ..  code-block:: c
 
@@ -118,9 +125,10 @@ In the example below, the C host API is used to generate 10 random floats using 
 C++ host API wrapper
 ====================
 
-The C++ host API wrapper provides resource management and an object-oriented interface for random number generation facilities.
+The C++ host API wrapper provides resource management and an object-oriented interface for random number
+generation facilities.
 
-In the example below C++ host API wrapper is used to produce a random number using the default generation parameters.
+The example below uses the C++ host API wrapper to produce a random number using the default generation parameters.
 
 ..  code-block:: cpp
 

--- a/docs/api-reference/cpp-api.rst
+++ b/docs/api-reference/cpp-api.rst
@@ -30,7 +30,7 @@ Follow these steps to use the device functions in the device kernel definition:
 4. Use the results.
 
 The rocRAND device functions are invoked from inside the user kernel.
-This means the generated numbers can be used right away in the kernel without the need to copy them to the host memory.
+This means the generated numbers can be used immediately in the kernel without copying them to the host memory.
 
 In the following example, random number generation uses the XORWOW generator.
 

--- a/docs/api-reference/data-type-support.rst
+++ b/docs/api-reference/data-type-support.rst
@@ -7,7 +7,8 @@
 rocRAND data type support
 ******************************************
 
-This topic discusses the various data types supported by rocRAND.
+This topic discusses the various data types supported by rocRAND and provides a comparison
+with the data type support in NVIDIA CUDA cuRAND.
 
 Host API
 ========
@@ -86,13 +87,13 @@ Generator types
       - ✅
       - ✅
 
-Only Sobol64, Scrambled Sobol64, ThreeFry 2x64-20, and ThreeFry 4x64-20 support generation of 64-bit :code:`unsigned long long int` integers.
+Only Sobol64, Scrambled Sobol64, ThreeFry 2x64-20, and ThreeFry 4x64-20 support the generation of 64-bit :code:`unsigned long long int` integers.
 The other generators generate 32-bit :code:`unsigned int` integers.
 
 Seed types
 ----------
 
-All generators can be seeded with :code:`unsigned long long`, however, LFSR113 can also be seeded using an :code:`uint4`.
+All generators can be seeded with :code:`unsigned long long`. However, LFSR113 can also be seeded using a :code:`uint4`.
 
 Output types
 ------------
@@ -129,7 +130,7 @@ Uniform distribution
       - ✅
     *
       - :code:`unsigned long long`
-      - 64 bit [#]_
+      - 64 bit (see note)
       - ✅
       - ✅
     *
@@ -150,6 +151,11 @@ Uniform distribution
 
 Uniform distributions of integral types return a number between 0 and 2^(size in bits) - 1,
 whereas floating-point types return a number between 0.0 and 1.0, excluding 1.0.
+
+.. note::
+
+   The generation of 64-bit :code:`unsigned long long` integers is only supported by 64-bit generators
+   (Scrambled Sobol 64, Sobol64, Threefry 2x64-20, and Threefry 4x64-20).
 
 Poisson distribution
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -311,8 +317,8 @@ Output types
 ------------
 
 The generators produce pseudo-random numbers chosen from a given distribution.
-The following distributions and corresponding output types are supported for the device API,
-however, not all generators support all types:
+The following distributions and corresponding output types are supported for the device API.
+However, not all generators support all types.
 
 
 Uniform distribution
@@ -505,6 +511,3 @@ Discrete distributions
       - ✅
       - Philox 4x32-10
       - ✅ - only Philox - 4x32-10
-
-.. rubric:: Footnotes
-.. [#] Generation of 64-bit :code:`unsigned long long` integers is only supported by 64-bit generators (Scrambled Sobol 64, Sobol64, Threefry 2x64-20, and Threefry 4x64-20).

--- a/docs/api-reference/data-type-support.rst
+++ b/docs/api-reference/data-type-support.rst
@@ -1,18 +1,23 @@
 .. meta::
-   :description: rocRAND documentation and API reference library
-   :keywords: rocRAND, ROCm, API, documentation, cuRAND
+   :description: Data type support for rocRAND documentation
+   :keywords: rocRAND, ROCm, API, documentation, cuRAND, data types
 
 .. _data-type-support:
 
 rocRAND data type support
 ******************************************
 
+This topic discusses the various data types supported by rocRAND.
+
 Host API
 ========
 
+This section covers the data types supported for the host API.
+
 Generator types
 ---------------
- .. list-table:: Supported generators on the host
+
+.. list-table:: Supported generators on the host
     :header-rows: 1
     :name: host-supported-generators
 
@@ -81,22 +86,24 @@ Generator types
       - ✅
       - ✅
 
-Only Sobol64, Scrambled Sobol64, ThreeFry 2x64-20 and ThreeFry 4x64-20 support generation of 64 bit :code:`unsigned long long int` integers, the other generators generate 32 bit :code:`unsigned int` integers.
+Only Sobol64, Scrambled Sobol64, ThreeFry 2x64-20, and ThreeFry 4x64-20 support generation of 64-bit :code:`unsigned long long int` integers.
+The other generators generate 32-bit :code:`unsigned int` integers.
 
 Seed types
 ----------
 
-All generators can be seeded with :code:`unsigned long long`, however LFSR113 can additionally be seeded using an :code:`uint4`.
+All generators can be seeded with :code:`unsigned long long`, however, LFSR113 can also be seeded using an :code:`uint4`.
 
 Output types
 ------------
 
-The generators produce pseudo-random numbers chosen from a given distribution. The following distributions and corresponding output types are supported for the host API:
+The generators produce pseudo-random numbers chosen from a given distribution.
+The following distributions and corresponding output types are supported for the host API:
 
 Uniform distribution
-""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for uniform distributions on the host
+.. list-table:: Supported types for uniform distributions on the host
     :header-rows: 1
     :name: host-types-uniform-distribution
 
@@ -141,14 +148,14 @@ Uniform distribution
       - ✅
       - ✅
 
-Uniform distributions of integral types return a number between 0 and 2^(size in bits) - 1, whereas floating-point types return a number between 0.0 and 1.0, excluding 1.0.
+Uniform distributions of integral types return a number between 0 and 2^(size in bits) - 1,
+whereas floating-point types return a number between 0.0 and 1.0, excluding 1.0.
 
 Poisson distribution
-"""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for the poisson distribution on the host
+.. list-table:: Supported types for the Poisson distribution on the host
     :header-rows: 1
-    :name: host-types-poisson-distribution
 
     *
       - Type
@@ -162,9 +169,9 @@ Poisson distribution
       - ✅
 
 Normal distribution
-"""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for normal distributions on the host
+.. list-table:: Supported types for normal distributions on the host
     :header-rows: 1
     :name: host-types-normal-distribution
 
@@ -190,9 +197,9 @@ Normal distribution
       - ✅
 
 Log-normal distributions
-""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for log-normal distributions on the host
+.. list-table:: Supported types for log-normal distributions on the host
     :header-rows: 1
     :name: host-types-log-normal-distribution
 
@@ -220,9 +227,13 @@ Log-normal distributions
 Device API
 ==========
 
+This section covers the supported data types for the device API.
+
+
 Generator types
 ---------------
- .. list-table:: Supported generators on the device
+
+.. list-table:: Supported generators on the device
     :header-rows: 1
     :name: device-supported-generators
 
@@ -294,40 +305,42 @@ Generator types
 Seed types
 ----------
 
-All generators can be seeded with :code:`unsigned long long`, however LFSR113 can additionally be seeded using an :code:`uint4`.
+All generators can be seeded with :code:`unsigned long long`, however LFSR113 can also be seeded using an :code:`uint4`.
 
 Output types
 ------------
 
-The generators produce pseudo-random numbers chosen from a given distribution. The following distributions and corresponding output types are supported for the device API, however not all generators support all types:
+The generators produce pseudo-random numbers chosen from a given distribution.
+The following distributions and corresponding output types are supported for the device API,
+however, not all generators support all types:
 
 
 Uniform distribution
-""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for uniform distributions on the device
+.. list-table:: Supported types for uniform distributions on the device
     :header-rows: 1
     :name: device-types-uniform-distribution
 
     *
       - Type
       - rocRAND support
-      - supported rocRAND generators
+      - Supported rocRAND generators
       - cuRAND support
     *
       - :code:`unsigned int`
       - ✅
-      - all native 32-bit generators
+      - All native 32-bit generators
       - ✅
     *
       - :code:`unsigned long long int`
       - ✅
-      - all native 64-bit generators
+      - All native 64-bit generators
       - ✅
     *
       - :code:`float`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`float2`
@@ -342,7 +355,7 @@ Uniform distribution
     *
       - :code:`double`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`double2`
@@ -357,21 +370,21 @@ Uniform distribution
 
 
 Normal distribution
-""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for normal distributions on the device
+.. list-table:: Supported types for normal distributions on the device
     :header-rows: 1
     :name: device-types-normal-distribution
 
     *
       - Type
       - rocRAND support
-      - supported rocRAND generators
+      - Supported rocRAND generators
       - cuRAND support
     *
       - :code:`float`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`float2`
@@ -386,7 +399,7 @@ Normal distribution
     *
       - :code:`double`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`double2`
@@ -400,21 +413,21 @@ Normal distribution
       - ❌
 
 Log-normal distributions
-""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for log-normal distributions on the device
+.. list-table:: Supported types for log-normal distributions on the device
     :header-rows: 1
     :name: device-types-log-normal-distribution
 
     *
       - Type
       - rocRAND support
-      - supported rocRAND generators
+      - Supported rocRAND generators
       - cuRAND support
     *
       - :code:`float`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`float2`
@@ -429,7 +442,7 @@ Log-normal distributions
     *
       - :code:`double`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`double2`
@@ -443,16 +456,16 @@ Log-normal distributions
       - ❌
 
 Poisson distributions
-"""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for poisson distributions on the device
+.. list-table:: Supported types for Poisson distributions on the device
     :header-rows: 1
     :name: device-types-poisson-distribution
 
     *
       - Type
       - rocRAND support
-      - supported rocRAND generators
+      - Supported rocRAND generators
       - cuRAND support
     *
       - :code:`unsigned int`
@@ -462,7 +475,7 @@ Poisson distributions
     *
       - :code:`unsigned long long int`
       - ✅
-      - Sobol64, Scrambled sobol64
+      - Sobol64, Scrambled Sobol64
       - ❌
     *
       - :code:`uint4`
@@ -471,21 +484,21 @@ Poisson distributions
       - ✅
 
 Discrete distributions
-""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
- .. list-table:: Supported types for discrete distributions on the device
+.. list-table:: Supported types for discrete distributions on the device
     :header-rows: 1
     :name: device-types-discrete-distribution
 
     *
       - Type
       - rocRAND support
-      - supported rocRAND generators
+      - Supported rocRAND generators
       - cuRAND support
     *
       - :code:`unsigned int`
       - ✅
-      - all generators
+      - All generators
       - ✅
     *
       - :code:`uint4`
@@ -494,4 +507,4 @@ Discrete distributions
       - ✅ - only Philox - 4x32-10
 
 .. rubric:: Footnotes
-.. [#] Generation of 64 bit :code:`unsigned long long` integers is only supported by 64 bit generators (Scrambled Sobol 64, Sobol64, Threefry 2x64-20 and Threefry 4x64-20).
+.. [#] Generation of 64-bit :code:`unsigned long long` integers is only supported by 64-bit generators (Scrambled Sobol 64, Sobol64, Threefry 2x64-20, and Threefry 4x64-20).

--- a/docs/api-reference/python-api.rst
+++ b/docs/api-reference/python-api.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: rocRAND documentation and API reference library
-  :keywords: rocRAND, ROCm, API, documentation
+  :description: rocRAND Python API reference
+  :keywords: rocRAND, ROCm, API, documentation, Python
   
 .. _python-api:
 
@@ -13,7 +13,7 @@ This chapter describes the rocRAND Python module API.
 API index
 ------------
 
-To search an API, refer to the API :ref:`genindex`.
+To search the API, see the API :ref:`genindex`.
 
 .. default-domain:: py
 .. py:currentmodule:: rocrand
@@ -51,4 +51,4 @@ Utilities
 
 .. autofunction:: rocrand.get_version
 
-To search an API, refer to the :ref:`genindex` for all rocRAND APIs.
+To search the API, see the :ref:`genindex` for all rocRAND APIs.

--- a/docs/conceptual/curand-compatibility.rst
+++ b/docs/conceptual/curand-compatibility.rst
@@ -1,5 +1,5 @@
 .. meta::
-   :description: rocRAND documentation and API reference library
+   :description: rocRAND compatibility with cuRAND
    :keywords: rocRAND, ROCm, API, documentation, cuRAND
 
 .. _curand-compatibility:
@@ -10,7 +10,7 @@ cuRAND compatibility
 
 The following table shows which rocRAND generators produce the exact same sequence as the equivalent NVIDIA CUDA cuRAND generator when using legacy ordering, given the same seed, number of dimensions, and offset.
 
-.. table:: cuRAND Compatibility
+.. table:: cuRAND compatibility
     :widths: auto
 
     =================  =====================

--- a/docs/conceptual/dynamic_ordering_configuration.rst
+++ b/docs/conceptual/dynamic_ordering_configuration.rst
@@ -9,8 +9,8 @@ Kernel configurations for dynamic ordering
 =============================================================
 
 When dynamic ordering (``ROCRAND_ORDERING_PSEUDO_DYNAMIC``) is set, rocRAND selects the number of blocks and threads
-to launch on the GPU to best accommodate the specific GPU model.
-Consequently, the number of allocated generators and thereby the sequence of the generated numbers can also vary.
+to launch on the GPU to accommodate the specific GPU model best.
+Consequently, the number of allocated generators and the sequence of the generated numbers can also vary.
 
 The tuning, which is the selection of the most performant configuration for each GPU architecture,
 can be performed in an automated manner. The necessary tools and benchmarks for the tuning are provided
@@ -21,7 +21,7 @@ in the rocRAND repository. The following sections provide additional details abo
 Building the tuning benchmarks
 ==============================
 
-The principle behind the tuning is very simple. The random number generation kernel is run
+The principle behind the tuning is straightforward. The random number generation kernel is run
 for a list of kernel block size and kernel grid size combinations. The fastest combination
 is then selected as the dynamic ordering configuration for that particular device.
 rocRAND provides an executable target named ``benchmark_rocrand_tuning`` that runs the benchmarks with all these

--- a/docs/conceptual/dynamic_ordering_configuration.rst
+++ b/docs/conceptual/dynamic_ordering_configuration.rst
@@ -1,6 +1,6 @@
 .. meta::
-   :description: rocRAND documentation and API reference library
-   :keywords: rocRAND, ROCm, API, documentation
+   :description: rocRAND documentation for dynamic ordering configuration
+   :keywords: rocRAND, ROCm, API, documentation, dynamic ordering
 
 .. _dynamic-ordering-configuration:
 
@@ -8,85 +8,135 @@
 Kernel configurations for dynamic ordering
 =============================================================
 
-Overview
-========
+When dynamic ordering (``ROCRAND_ORDERING_PSEUDO_DYNAMIC``) is set, rocRAND selects the number of blocks and threads
+to launch on the GPU to best accommodate the specific GPU model.
+Consequently, the number of allocated generators and thereby the sequence of the generated numbers can also vary.
 
-When dynamic ordering (``ROCRAND_ORDERING_PSEUDO_DYNAMIC``) is set, the number of blocks and threads launched on the GPU is selected such that it best accommodates the specific GPU model. As a consequence, the number of allocated generators and thereby the sequence of the generated numbers can also vary.
-
-The tuning, i.e. the selection of the most performant configuration for each GPU architecture can be performed in an automated manner. The necessary tools and benchmarks for the tuning are provided in the rocRAND repository. In the following, the process of the tuning is described.
+The tuning, which is the selection of the most performant configuration for each GPU architecture,
+can be performed in an automated manner. The necessary tools and benchmarks for the tuning are provided
+in the rocRAND repository. The following sections provide additional details about the tuning process.
 
 .. _tuning-benchmark-build:
 
 Building the tuning benchmarks
 ==============================
 
-The principle of the tuning is very simple: the random number generation kernel is run for a list of kernel block size / kernel grid size combinations, and the fastest combination is selected as the dynamic ordering configuration for the particular device. rocRAND provides an executable target that runs the benchmarks with all these combinations: `benchmark_rocrand_tuning`. This target is disabled by default, and can be enabled and built by the following snippet.
+The principle behind the tuning is very simple. The random number generation kernel is run
+for a list of kernel block size and kernel grid size combinations. The fastest combination
+is then selected as the dynamic ordering configuration for that particular device.
+rocRAND provides an executable target named ``benchmark_rocrand_tuning`` that runs the benchmarks with all these
+combinations.
 
-Use the `GPU_TARGETS` variable to specify the comma-separated list of GPU architectures to build the benchmarks for. To acquire the architecture of the GPU(s) installed, run `rocminfo`, and look for `gfx` in the "ISA Info" section. ::
+This target is disabled by default, but it can be enabled and built using the following snippet.
+Use the ``GPU_TARGETS`` variable to specify a comma-separated list of GPU architectures to build the benchmarks for.
+To determine the architecture of the installed GPU(s), run the ``rocminfo`` command
+and look for ``gfx`` in the "ISA Info" section.
 
-    $ cd rocRAND
-    $ cmake -S . -B ./build
-        -D BUILD_BENCHMARK=ON
-        -D BUILD_BENCHMARK_TUNING=ON
-        -D CMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++
-        -D GPU_TARGETS=gfx908
-    $ cmake --build build --target benchmark_rocrand_tuning
+.. code-block:: shell
 
-Additionally, the following CMake cache variables control the generation of the benchmarked matrix:
+   cd rocRAND
+   cmake -S . -B ./build
+      -D BUILD_BENCHMARK=ON
+      -D BUILD_BENCHMARK_TUNING=ON
+      -D CMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++
+      -D GPU_TARGETS=gfx908
+   cmake --build build --target benchmark_rocrand_tuning
+
+The following CMake cache variables control the generation of the benchmarked matrix:
 
 ========================================== ===============================================================
 Variable name                              Explanation
 ========================================== ===============================================================
 ``BENCHMARK_TUNING_THREAD_OPTIONS``        Comma-separated list of benchmarked block sizes
 ``BENCHMARK_TUNING_BLOCK_OPTIONS``         Comma-separated list of benchmarked grid sizes
-``BENCHMARK_TUNING_MIN_GRID_SIZE``         Configurations with fewer total number of threads are omitted
+``BENCHMARK_TUNING_MIN_GRID_SIZE``         Configurations with fewer total threads are omitted
 ========================================== ===============================================================
 
-Note, that currently the benchmark tuning is only supported for AMD GPUs. 
+.. note::
+
+   The benchmark tuning is only supported for AMD GPUs. 
 
 Using the number of multiprocessors as candidates
 -------------------------------------------------
 
-Multiples of the number of multiprocessors of the GPU at hand are good candidates for ``BENCHMARK_TUNING_BLOCK_OPTIONS``. Running `rocRAND/scripts/config-tuning/get_tuned_grid_sizes.py` executes `rocminfo` to acquire the number of multiprocessors, and prints a comma-separated list of grid size candidates to the standard output.
+Multiples of the number of multiprocessors on the GPU being benchmarked are
+good candidate values for ``BENCHMARK_TUNING_BLOCK_OPTIONS``. 
+The ``rocRAND/scripts/config-tuning/get_tuned_grid_sizes.py`` executable
+runs ``rocminfo`` to acquire the number of multiprocessors and prints a comma-separated list
+of grid size candidates to the standard output.
 
 .. _tuning-benchmark-run:
 
 Running the tuning benchmarks
 =============================
 
-When the `benchmark_rocrand_tuning` target is built, the benchmarks can be run and the results can be collected for further processing. Since the benchmarks run for a longer time period, it is crucial that the GPU in use is thermally stable, i.e. the cooling must be adequate enough to keep the GPU at the preset clock rates without throttling. Additionally, make sure that no other workload is dispatched on the GPU concurrently. Otherwise the resulting dynamic ordering configs might not be the optimal ones. The full benchmark suite can be run with the following command: ::
+After building the ``benchmark_rocrand_tuning`` target, you can run the benchmarks
+and collect the results for further processing.
+The benchmarks can run for a long time, so it is crucial that the GPU in use is thermally stable.
+For instance, there must be adequate cooling to keep the GPU at the preset clock rates without throttling.
+Additionally, ensure that no other workload is concurrently dispatched to the GPU.
+Otherwise, the resulting dynamic ordering configurations might not be the optimal ones.
+Run the full benchmark suite using the following command:
 
-    $ cd ./build/benchmark/tuning
-    $ ./benchmark_rocrand_tuning --benchmark_out_format=json --benchmark_out=rocrand_tuning_gfx908.json
+.. code-block:: shell
 
-This executes the benchmarks and saves the benchmark results into the JSON file at `rocrand_tuning_gfx908.json`. If only a subset of the benchmarks needs to be run, e.g. for a single generator, the `--benchmark_filter=<regex>` option can be used. For example: `--benchmark_filter=".*philox.*"`.
+   cd ./build/benchmark/tuning
+   ./benchmark_rocrand_tuning --benchmark_out_format=json --benchmark_out=rocrand_tuning_gfx908.json
+
+This executes the benchmarks and saves the benchmark results to the ``rocrand_tuning_gfx908.json`` JSON file.
+To only run a subset of the benchmarks, such as for a single generator, use the ``--benchmark_filter=<regex>`` option,
+for example, ``--benchmark_filter=".*philox.*"``.
 
 .. _tuning-benchmark-process:
 
 Processing the benchmark results
 ================================
 
-Once the benchmark results in JSON format from all architectures are present, the best configs are selected using the `rocRAND/scripts/config-tuning/select_best_config.py` script. Make sure that the prerequisite libraries are installed, by running ``pip install -r rocRAND/scripts/config-tuning/requirements.txt``.
+After the benchmark results from all architectures in JSON format are available, the best configurations
+are selected using the ``rocRAND/scripts/config-tuning/select_best_config.py`` script.
+Ensure the prerequisite libraries are installed by running the following command:
 
-Each rocRAND generator is capable of generating a multitude of output types and distributions. However, a single configuration is selected for each GPU architecture, which applies uniformly to all types and distributions. It is possible that the configuration that performs the best for one distribution is not the fastest for another. `select_best_config.py` selects the configuration that performs best **on average**. If, under the selected configuration, any type/distribution performs worse than ``ROCRAND_ORDERING_PSEUDO_DEFAULT``, a warning is printed to the standard output. The eventual decision about applying the configuration or not have to be made by the library's maintainers.
+.. code-block:: shell
 
-The main output of running `select_best_config.py` is a number of C++ header files that contain the definitions of the dynamic ordering config for the benchmarked architectures. These files are intended to be copied to the `rocRAND/library/src/rng/config` directory of the source tree to be checked in to the version control. The directory, to which the header files are written, can be specified with the `--out-dir` option.
+   pip install -r rocRAND/scripts/config-tuning/requirements.txt.
 
-To help humans comprehend the results, `select_best_config.py` can generate colorized diagrams to visually compare the performance of the configuration candidates. This can be invoked by passing the optional `--plot-out` argument, e.g. `--plot-out rocrand-tuning.svg`. This generates an SVG image for each GPU architecture the script has processed.
+Each rocRAND generator can generate a multitude of output types and distributions.
+However, a single configuration is selected for each GPU architecture, which applies uniformly to all types
+and distributions. It's possible that the best performing configuration for one distribution
+isn't the fastest for another. ``select_best_config.py`` selects the configuration that performs best **on average**.
+If any type or distribution performs worse than ``ROCRAND_ORDERING_PSEUDO_DEFAULT`` under the selected configuration,
+a warning is printed to the standard output.
+The eventual decision about whether to apply the configuration is made by the library's maintainers.
 
-To put it all together, a potential invocation of the `select_best_config.py` script: ::
+The ``select_best_config.py``  script produces a set of C++ header files as output
+that contain the definitions of the dynamic ordering configuration for the benchmarked architectures.
+These files are intended to be copied to the ``rocRAND/library/src/rng/config`` directory of the source tree
+and checked in to the version control system. The directory where the header files are written to
+can be specified using the ``--out-dir`` option.
 
-    $ ./rocRAND/scripts/config-tuning/select_best_config.py --plot-out ./rocrand-tuning.svg --out-dir ./rocRAND/library/src/rng/config/ ./rocRAND/build/benchmark/tuning/rocrand_tuning_gfx908.json ./rocRAND/build/benchmark/tuning/rocrand_tuning_gfx1030.json
+For more readable results, ``select_best_config.py`` can generate colorized diagrams to visually
+compare the performance of the configuration candidates. To select this option, use the
+optional ``--plot-out`` argument, for example, ``--plot-out rocrand-tuning.svg``.
+This generates an SVG image for each GPU architecture processed by the script.
+
+The following invokation of the ``select_best_config.py`` script demonstrates all these options:
+
+.. code-block:: shell
+
+   ./rocRAND/scripts/config-tuning/select_best_config.py --plot-out ./rocrand-tuning.svg --out-dir ./rocRAND/library/src/rng/config/ ./rocRAND/build/benchmark/tuning/rocrand_tuning_gfx908.json ./rocRAND/build/benchmark/tuning/rocrand_tuning_gfx1030.json
 
 Adding support for a new GPU architecture
 =========================================
 
-The intended audience of this section is the developer, who is adding support to rocRAND for a new GPU architecture.
+This section is intended for developers who want to add rocRAND support for a new GPU architecture.
+To add support, follow this checklist:
 
-1. The list of the recognized architectures are hard-coded in source file `library/src/rng/config_types.hpp`. The following symbols have to be updated accordingly:
-    * Enum class ``target_arch`` - lists the recognized architectures as an enumeration.
-    * Function ``get_device_arch`` - recognizes the device that we compile to in device code.
-    * Function ``parse_gcn_arch`` - dispatches from the name of the architecture to the ``target_arch`` enum in host code.
-2. The tuning benchmarks has to be compiled and run for the new architecture. See :ref:`tuning-benchmark-build` and :ref:`tuning-benchmark-run`.
-3. The benchmark results have to be processed by the provided `select_best_config.py` script. See :ref:`tuning-benchmark-process`.
-4. The resulting header files have to be merged with the ones that are checked in the version control in directory `rocRAND/library/src/rng/config`.
+#. Update the hard-coded list of recognized architectures in the ``library/src/rng/config_types.hpp`` file. The following symbols must be updated accordingly:
+
+   *  Enum class ``target_arch``: Lists the recognized architectures as an enumeration.
+   *  Function ``get_device_arch``: The device to compile to in the device code.
+   *  Function ``parse_gcn_arch``: Translates from the name of the architecture to the ``target_arch`` enum in the host code.
+
+#. The tuning benchmarks must be compiled and run for the new architecture. See :ref:`tuning-benchmark-build` and :ref:`tuning-benchmark-run`.
+#. The benchmark results must be processed by the ``select_best_config.py`` script. See :ref:`tuning-benchmark-process`.
+#. The resulting header files must be added to version control in the ``rocRAND/library/src/rng/config`` directory.

--- a/docs/conceptual/programmers-guide.rst
+++ b/docs/conceptual/programmers-guide.rst
@@ -51,16 +51,16 @@ The following ordering types are available:
 *  ``ROCRAND_ORDERING_QUASI_DEFAULT``
 
 ``ROCRAND_ORDERING_PSEUDO_DEFAULT`` and ``ROCRAND_ORDERING_QUASI_DEFAULT`` are the default ordering types
-for pseudo- and quasi-random number generators respectively. ``ROCRAND_ORDERING_PSEUDO_DEFAULT`` is the
+for pseudo- and quasi-random number generators, respectively. ``ROCRAND_ORDERING_PSEUDO_DEFAULT`` is the
 same as ``ROCRAND_ORDERING_PSEUDO_BEST`` and ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
 
 ``ROCRAND_ORDERING_PSEUDO_DYNAMIC`` indicates that rocRAND can change the output ordering
 to obtain the best performance for a particular generator on a particular GPU.
-Using this ordering, the generated sequences can vary between different GPU models and rocRAND versions.
+Using this ordering, the generated sequences can vary between GPU models and rocRAND versions.
 For more information about generating these configurations, see :doc:`dynamic_ordering_configuration`.
 ``ROCRAND_ORDERING_PSEUDO_DYNAMIC`` is not supported for generators created with ``rocrand_create_generator_host``.
 
-``ROCRAND_ORDERING_PSEUDO_LEGACY`` indicates that rocRAND should generate values in a way that is backward compatible.
+``ROCRAND_ORDERING_PSEUDO_LEGACY`` indicates that rocRAND should generate values in a backward-compatible way.
 When this type is set, rocRAND generates exactly the same sequences across releases.
 
 All supported orderings for all generators are listed below:

--- a/docs/conceptual/programmers-guide.rst
+++ b/docs/conceptual/programmers-guide.rst
@@ -1,163 +1,181 @@
 .. meta::
-  :description: rocRAND documentation and API reference library
-  :keywords: rocRAND, ROCm, API, documentation
+  :description: Programming guide for rocRAND
+  :keywords: rocRAND, ROCm, API, documentation, programming, generator types
   
 .. _programmers-guide:
 
-==================
-Programmer's guide
-==================
+*******************************************************************
+rocRAND programming guide
+*******************************************************************
+
+This topic discusses some issues to consider when using rocRAND in your application.
 
 Generator types
-===============
+===============================
 
-There are two main classes of generator in rocRAND: Pseudo-Random Number Generators (PRNGs), and Quasi-Random Number Generators (QRNGs). The following pseudo-random number generators are available:
+There are two main generator classes in rocRAND
 
-* XORWOW.
-* MRG32K3A.
-* MTGP32.
-* Philox 4x32-10.
-* MRG31K3P.
-* LFSR113.
-* MT19937.
-* ThreeFry 2x32-20, 4x32-30, 2x64-20 and 4x64-20.
+*  Pseudo-Random Number Generators (PRNGs)
+*  Quasi-Random Number Generators (QRNGs)
 
-Additionally, the following quasi-random number generators are available:
+The following pseudo-random number generators are available:
 
-* Sobol32.
-* Sobol64.
-* Scrambled Sobol32.
-* Scrambled Sobol64.
+*  XORWOW
+*  MRG32K3A
+*  MTGP32
+*  Philox 4x32-10
+*  MRG31K3P
+*  LFSR113
+*  MT19937
+*  ThreeFry 2x32-20, 4x32-30, 2x64-20, and 4x64-20
+
+The following quasi-random number generators are available:
+
+*  Sobol32
+*  Sobol64
+*  Scrambled Sobol32
+*  Scrambled Sobol64
 
 Ordering
 ========
 
-rocRAND generators can be configured to change how results are ordered in global memory. These parameters can be used to, for example, tune the performance versus the reproducibility of rocRAND generators. The following ordering types are available:
+rocRAND generators can be configured to change how the results are ordered in global memory.
+These parameters can be used to, for example, tune the performance versus the reproducibility of rocRAND generators.
+The following ordering types are available:
 
-* `ROCRAND_ORDERING_PSEUDO_BEST`
-* `ROCRAND_ORDERING_PSEUDO_DEFAULT`
-* `ROCRAND_ORDERING_PSEUDO_SEEDED`
-* `ROCRAND_ORDERING_PSEUDO_LEGACY`
-* `ROCRAND_ORDERING_PSEUDO_DYNAMIC`
-* `ROCRAND_ORDERING_QUASI_DEFAULT`
+*  ``ROCRAND_ORDERING_PSEUDO_BEST``
+*  ``ROCRAND_ORDERING_PSEUDO_DEFAULT``
+*  ``ROCRAND_ORDERING_PSEUDO_SEEDED``
+*  ``ROCRAND_ORDERING_PSEUDO_LEGACY``
+*  ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``
+*  ``ROCRAND_ORDERING_QUASI_DEFAULT``
 
-`ROCRAND_ORDERING_PSEUDO_DEFAULT` and `ROCRAND_ORDERING_QUASI_DEFAULT` are the default ordering for pseudo- and quasi-random number generators respectively. `ROCRAND_ORDERING_PSEUDO_DEFAULT` is currently the same as `ROCRAND_ORDERING_PSEUDO_BEST` and `ROCRAND_ORDERING_PSEUDO_LEGACY`.
+``ROCRAND_ORDERING_PSEUDO_DEFAULT`` and ``ROCRAND_ORDERING_QUASI_DEFAULT`` are the default ordering types
+for pseudo- and quasi-random number generators respectively. ``ROCRAND_ORDERING_PSEUDO_DEFAULT`` is the
+same as ``ROCRAND_ORDERING_PSEUDO_BEST`` and ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
 
-`ROCRAND_ORDERING_PSEUDO_DYNAMIC` indicates that rocRAND may change the output ordering such that the best performance is obtained for a particular generator on a particular GPU. Using this ordering, the generated sequences can vary between different GPU models and rocRAND versions. More information about generating such configurations can be found at :doc:`dynamic_ordering_configuration`. `ROCRAND_ORDERING_PSEUDO_DYNAMIC` is not supported for generators created with `rocrand_create_generator_host`.
+``ROCRAND_ORDERING_PSEUDO_DYNAMIC`` indicates that rocRAND can change the output ordering
+to obtain the best performance for a particular generator on a particular GPU.
+Using this ordering, the generated sequences can vary between different GPU models and rocRAND versions.
+For more information about generating these configurations, see :doc:`dynamic_ordering_configuration`.
+``ROCRAND_ORDERING_PSEUDO_DYNAMIC`` is not supported for generators created with ``rocrand_create_generator_host``.
 
-`ROCRAND_ORDERING_PSEUDO_LEGACY` indicates that rocRAND should generate values in a way that is backward compatible. When it is set, rocRAND generates exactly the same sequences across releases.
+``ROCRAND_ORDERING_PSEUDO_LEGACY`` indicates that rocRAND should generate values in a way that is backward compatible.
+When this type is set, rocRAND generates exactly the same sequences across releases.
 
-All supported orderings for all generators are detailed below:
+All supported orderings for all generators are listed below:
 
 .. table:: XORWOW ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_SEEDED`    The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There are :math:`131072` generators in total, each of which are separated by :math:`2^{67}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{67} + \lfloor n / 131072 \rfloor` in the XORWOW sequence for a particular seed.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_SEEDED``    The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There are :math:`131072` generators in total, each of which are separated by :math:`2^{67}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{67} + \lfloor n / 131072 \rfloor` in the XORWOW sequence for a particular seed.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: MRG32K3A ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There are :math:`131072` generators in total, each of which are separated by :math:`2^{76}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{76} + \lfloor n / 131072 \rfloor` in the MRG32K3A sequence for a particular seed.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There are :math:`131072` generators in total, each of which are separated by :math:`2^{76}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{76} + \lfloor n / 131072 \rfloor` in the MRG32K3A sequence for a particular seed.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: MTGP32 ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There are :math:`512` generators in total, each of which generates :math:`256` values per iteration. Blocks of :math:`256` elements from generators are concatenated to form the output. The result at offset :math:`n` in memory is generated from generator :math:`\lfloor n / 256\rfloor\;\mathrm{mod}\; 512`.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There are :math:`512` generators in total, each of which generates :math:`256` values per iteration. Blocks of :math:`256` elements from generators are concatenated to form the output. The result at offset :math:`n` in memory is generated from generator :math:`\lfloor n / 256\rfloor\;\mathrm{mod}\; 512`.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: Philox 4x32-10 ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There is only one Philox generator, and the result at offset :math:`n` is simply the :math:`n`-th value from this generator.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There is only one Philox generator, and the result at offset :math:`n` is the :math:`n`-th value from this generator.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: MT19937 ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    The Mersenne Twister sequence is generated from :math:`8192` generators in total, and each of these are separated by :math:`2^{1000}` values. Each generator generates :math:`8` elements per iteration. The result at offset :math:`n` is generated from generator :math:`(\lfloor n / 8\rfloor\;\mathrm{mod}\; 8192) \cdot 2^{1000} + \lfloor n / (8 \cdot 8192) \rfloor + \lfloor n / 8 \rfloor`.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    The Mersenne Twister sequence is generated from :math:`8192` generators in total, and each of these are separated by :math:`2^{1000}` values. Each generator generates :math:`8` elements per iteration. The result at offset :math:`n` is generated from generator :math:`(\lfloor n / 8\rfloor\;\mathrm{mod}\; 8192) \cdot 2^{1000} + \lfloor n / (8 \cdot 8192) \rfloor + \lfloor n / 8 \rfloor`.
+    ====================================  ====================================================================================================================
 
 .. table:: MRG31K3P ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There are :math:`131072` generators in total, each of which are separated by :math:`2^{72}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{72} + \lfloor n / 131072 \rfloor` in the MRG31K3P sequence for a particular seed.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There are :math:`131072` generators in total, each of which are separated by :math:`2^{72}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{72} + \lfloor n / 131072 \rfloor` in the MRG31K3P sequence for a particular seed.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: LFSR113 ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There are :math:`131072` generators in total, each of which are separated by :math:`2^{55}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{55} + \lfloor n / 131072 \rfloor` in the LFSR113 sequence for a particular seed.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There are :math:`131072` generators in total, each of which are separated by :math:`2^{55}` values. The results are generated in an interleaved fashion. The result at offset :math:`n` in memory is generated from offset :math:`(n\;\mathrm{mod}\; 131072) \cdot 2^{55} + \lfloor n / 131072 \rfloor` in the LFSR113 sequence for a particular seed.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: ThreeFry ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_PSEUDO_BEST`      The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_DEFAULT`   The same as `ROCRAND_ORDERING_PSEUDO_LEGACY`.
-    `ROCRAND_ORDERING_PSEUDO_LEGACY`    There is only one ThreeFry generator, and the results at offset :math:`n` is simply the :math:`n`-th value from this generator.
-    `ROCRAND_ORDERING_PSEUDO_DYNAMIC`   The ordering depends on the GPU that is used.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_PSEUDO_BEST``      The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_DEFAULT``   The same as ``ROCRAND_ORDERING_PSEUDO_LEGACY``.
+    ``ROCRAND_ORDERING_PSEUDO_LEGACY``    There is only one ThreeFry generator, and the result at offset :math:`n` is the :math:`n`-th value from this generator.
+    ``ROCRAND_ORDERING_PSEUDO_DYNAMIC``   The ordering depends on the GPU that is used.
+    ====================================  ====================================================================================================================
 
 .. table:: Sobol ordering support
     :widths: auto
 
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
     Ordering                            
-    ==================================  ====================================================================================================================
-    `ROCRAND_ORDERING_QUASI_DEFAULT`    The (scrambled) 32- and 64-bit sobol quasi-random number generators generated the result from :math:`d` dimensions by flattening them into the output. The result at offset :math:`n` in memory is generated from offset :math:`n\;\mathrm{mod}\; d` in dimension :math:`\lfloor n / d \rfloor`, where :math:`d` is the generator's number of dimensions.
-    ==================================  ====================================================================================================================
+    ====================================  ====================================================================================================================
+    ``ROCRAND_ORDERING_QUASI_DEFAULT``    The (scrambled) 32- and 64-bit sobol quasi-random number generators generated the result from :math:`d` dimensions by flattening them into the output. The result at offset :math:`n` in memory is generated from offset :math:`n\;\mathrm{mod}\; d` in dimension :math:`\lfloor n / d \rfloor`, where :math:`d` is the generator's number of dimensions.
+    ====================================  ====================================================================================================================
 
 Using rocRAND in HIP Graphs
 ===========================
 
-rocRAND supports the capturing of the random number generation with HIP Graphs. However, the construction, initialization and cleanup of the generator objects must take place outside of the recorded section. See the following example (error handling omitted for brevity):
+rocRAND supports capturing the random number generation with HIP Graphs.
+However, the construction, initialization, and cleanup of the generator objects must take place
+outside of the recorded section. See the following example (error handling is omitted for brevity):
 
 .. literalinclude:: ../../test/hipgraphs_doc_sample.hpp
     :language: c++

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ shutil.copy2('../library/src/fortran/README.md', './fortran-api-reference.md')
 # for PDF output on Read the Docs
 project = "rocRAND Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -12,6 +12,6 @@
 The rocRAND project provides functions that generate pseudo-random and quasi-random numbers.
 
 The rocRAND library is implemented in the [HIP](https://rocm.docs.amd.com/projects/HIP/en/latest/index.html)
-programming language and optimized for AMD's latest discrete GPUs. It is designed to run on top
-of AMD's [ROCm](https://rocm.docs.amd.com/en/latest/), but it also works on CUDA-enabled GPUs.
+programming language and optimized for the latest AMD discrete GPUs. It is designed to run on top
+of AMD [ROCm](https://rocm.docs.amd.com/en/latest/), but it also works on CUDA-enabled GPUs.
 */

--- a/library/src/fortran/README.md
+++ b/library/src/fortran/README.md
@@ -2,9 +2,9 @@
 
 This library provides a pure Fortran interface for the rocRAND API.
 
-This interface is intended to target only Host API functions, and provides a mapping to some of
-the C Host API functions in rocRAND. For documentation of these functions, please
-refer to the C Host API functions documentation.
+This interface is intended to target only Host API functions. It provides a mapping to some of
+the C Host API functions in rocRAND. For documentation of these functions, see
+the C Host API functions documentation.
 
 ## Deprecation notice
 
@@ -12,8 +12,8 @@ This library is currently deprecated in favor of [hipfort](https://github.com/RO
 
 ## Build and install
 
-The Fortran interface is installed as part of the rocRAND package. Simply add the build
-option `-DBUILD_FORTRAN_WRAPPER=ON` when configuring the project, as below:
+The Fortran interface is installed as part of the rocRAND package. Add the build
+option `-DBUILD_FORTRAN_WRAPPER=ON` when configuring the project, as shown below:
 
 ```shell
 cmake -DBUILD_FORTRAN_WRAPPER=ON ...
@@ -21,27 +21,27 @@ cmake -DBUILD_FORTRAN_WRAPPER=ON ...
 
 ## Running unit tests
 
-After having configured the project with testing enabled (with option `-DBUILD_TEST=ON`), follow the steps below
+Configure the project with testing enabled, using the `-DBUILD_TEST=ON` option, then follow the steps below
 to build and run the unit tests.
 
-1. Go to rocRAND build directory
+1. Go to the rocRAND `build` directory:
 ```shell
 cd /path/to/rocRAND/build
 ```
 
-2. Build unit tests for Fortran interface
+2. Build the unit tests for the Fortran interface:
 ```shell
 cmake --build . --target test_rocrand_fortran_wrapper
 ```
 
-3. Run unit tests
+3. Run the unit tests:
 ```shell
 ./test/test_rocrand_fortran_wrapper
 ```
 
 ## Usage
 
-Below is an example of writing a simple Fortran program that generates a set of uniform values.
+Here is an example of how to write a simple Fortran program that generates a set of uniform values.
 
 ```fortran
 integer(kind =8) :: gen
@@ -57,7 +57,7 @@ status = hipFree(d_x)
 status = rocrand_destroy_generator(gen)
 ```
 
-And when compiling the source code with a Fortran compiler, the following should be linked[^1]:
+When compiling the source code with a Fortran compiler, the following items should be linked[^1]:
 
 ```shell
 # Compile on an NVCC platform (link CUDA libraries: cuda, cudart).
@@ -68,4 +68,4 @@ gfortran <input-file>.f90 hip_m.f90 rocrand_m.f90  -lrocrand_fortran -lrocrand -
 gfortran <input-file>.f90 hip_m.f90 rocrand_m.f90  -lrocrand_fortran -lrocrand -L${HIP_ROOT_DIR}/lib
 ```
 
-[^1]: `gfortran` is used in this example, however other Fortran compilers should work.
+[^1]: `gfortran` is used in this example, however, other Fortran compilers should work.


### PR DESCRIPTION
This performs copy edits and formatting fixes for the remainder of the rocRAND docs in the API-reference (except of the auto-generated Doxygen-based content) and conceptual sections