### PR TITLE
Update version number for ROCm 6.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocRAND is available at
 [https://rocm.docs.amd.com/projects/rocRAND/en/latest/](https://rocm.docs.amd.com/projects/rocRAND/en/latest/)
 
-## (Unreleased) rocRAND 3.4.0 for ROCm 6.5
+## rocRAND 3.4.0 for ROCm 6.5
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
 endif()
 
 # Set version variables
-rocm_setup_version( VERSION "3.3.0" )
+rocm_setup_version( VERSION "3.4.0" )
 set ( rocrand_VERSION ${rocRAND_VERSION} )
 # Old-style version number used within the library's API. rocrand_get_version should be modified.
 math(EXPR rocrand_VERSION_NUMBER "${rocRAND_VERSION_MAJOR} * 100000 + ${rocRAND_VERSION_MINOR} * 100 + ${rocRAND_VERSION_PATCH}")


### PR DESCRIPTION
This change updates the rocRAND version number to 3.4.0. It also updates the changelog to remove the "(unreleased)" note from the 6.5.0 heading.