### PR TITLE
Develop stream 2025-05-07

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,35 @@
+
+CompileFlags:
+    CompilationDatabase: build/release/
+    Compiler: hipcc
+    Add: 
+        - -x
+        - hip
+        - -D__AMDGCN_WAVEFRONT_SIZE=64
+        - -isystem/opt/rocm/include/
+        - -ferror-limit=0
+
+Diagnostics:
+    ClangTidy:
+        Add:
+            - readability-braces-around-statements
+            - readability-*
+            - bugprone-*
+        Remove:
+            - readability-function-cognitive-complexity
+            - readability-identifier-length
+            - bugprone-easily-swappable-parameters
+
+
+---
+If:
+
+    PathMatch: test/.*
+
+CompileFlags:
+    CompilationDatabase: build/release/
+
+Diagnostics:
+    ClangTidy:
+        Remove:
+            - readability-magic-numbers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,7 +190,7 @@ copyright-date:
       -D CMAKE_C_COMPILER_LAUNCHER=phc_sccache_c
       -D CMAKE_CXX_COMPILER_LAUNCHER=phc_sccache_cxx
       -D CMAKE_CUDA_COMPILER_LAUNCHER=phc_sccache_cuda
-      -D CMAKE_CXX_STANDARD=14
+      -D CMAKE_CXX_STANDARD=17
     - cmake --build $CI_PROJECT_DIR/build
     - if [[ "${BUILD_SHARED_LIBS}" = "ON" ]]; then cmake --build $CI_PROJECT_DIR/build --target package; fi
 
@@ -198,6 +198,7 @@ copyright-date:
 .save-artifacts:
   artifacts:
     paths:
+      - $CI_PROJECT_DIR/build/lib/
       - $CI_PROJECT_DIR/build/library/
       - $CI_PROJECT_DIR/build/test/test_*
       - $CI_PROJECT_DIR/build/**/CTestTestfile.cmake
@@ -217,7 +218,7 @@ build:rocm-cmake-minimum:
   variables:
     BUILD_SHARED_LIBS: "ON"
     BUILD_BENCHMARK_TUNING: "ON"
-    BUILD_VERSION: 14
+    BUILD_VERSION: 17
 
 build:rocm-hipcc-cmake-minimum:
   tags:
@@ -229,7 +230,7 @@ build:rocm-hipcc-cmake-minimum:
     - .save-artifacts
   variables:
     BUILD_SHARED_LIBS: "ON"
-    BUILD_VERSION: 14
+    BUILD_VERSION: 17
 
 build:rocm-static-cmake-minimum:
   tags:
@@ -240,7 +241,7 @@ build:rocm-static-cmake-minimum:
     - .rocm:build
   variables:
     BUILD_SHARED_LIBS: "OFF"
-    BUILD_VERSION: 14
+    BUILD_VERSION: 17
 
 build:rocm-cmake-latest:
   tags:
@@ -253,7 +254,7 @@ build:rocm-cmake-latest:
     BUILD_SHARED_LIBS: "ON"
   parallel:
     matrix:
-      - BUILD_VERSION: [14, 17]
+      - BUILD_VERSION: 17
 
 
 build:nvcc-cmake-minimum:
@@ -331,7 +332,7 @@ benchmark:benchmark-tuning:
       -D BENCHMARK_TUNING_BLOCK_OPTIONS="${BENCHMARK_TUNING_BLOCK_OPTIONS}"
       -D CMAKE_C_COMPILER_LAUNCHER=phc_sccache_c
       -D CMAKE_CXX_COMPILER_LAUNCHER=phc_sccache_cxx
-      -D CMAKE_CXX_STANDARD=14
+      -D CMAKE_CXX_STANDARD=17
     - cmake --build $CI_PROJECT_DIR/build --target benchmark_rocrand_tuning
     - $CI_PROJECT_DIR/build/benchmark/tuning/benchmark_rocrand_tuning --benchmark_out_format=json --benchmark_out=$CI_PROJECT_DIR/build/rocrand_config_tuning_${GPU_TARGET}_${CI_JOB_ID}.json
   artifacts:
@@ -616,10 +617,11 @@ test:nvcc-parity:
       -D BUILD_TEST=ON
       -D CMAKE_BUILD_TYPE=Release
       -D CMAKE_CXX_COMPILER:FILEPATH="${env:HIP_PATH}/bin/clang++.exe"
+      -D CMAKE_CXX_FLAGS="-Wno-ignored-attributes"
       -D CMAKE_INSTALL_PREFIX:PATH="$CI_PROJECT_DIR/build/install"
       -D CMAKE_PREFIX_PATH:PATH="${env:HIP_PATH}/lib/cmake"
-      -D DISABLE_WERROR=OFF *>&1
-      -D CMAKE_CXX_STANDARD=14
+      -D DISABLE_WERROR=OFF
+      -D CMAKE_CXX_STANDARD=17 *>&1
     # Building
     - cmake --build "$CI_PROJECT_DIR/build" *>&1
 
@@ -648,11 +650,13 @@ test:windows:
       -D CMAKE_BUILD_TYPE=Release
       -D CMAKE_CXX_COMPILER:FILEPATH="${env:HIP_PATH}/bin/clang++.exe"
       -D CMAKE_PREFIX_PATH:FILEPATH="${env:HIP_PATH}/lib/cmake;$CI_PROJECT_DIR/build/install" *>&1
-      -D CMAKE_CXX_STANDARD=14
+      -D CMAKE_CXX_STANDARD=17
     # Build package test
     - cmake --build "$CI_PROJECT_DIR/build_install_test"
     # Copy rocRAND.dll to the package test build directory
     - cmake -E copy "$CI_PROJECT_DIR/build/install/bin/rocRAND.dll" "$CI_PROJECT_DIR/build_install_test" *>&1
+    - cmake -E copy "$CI_PROJECT_DIR/build/_deps/googlebenchmark-build/src/benchmark.dll" "$CI_PROJECT_DIR/build_install_test" *>&1
+    - cmake -E copy "$CI_PROJECT_DIR/build/_deps/googlebenchmark-build/src/benchmark_main.dll" "$CI_PROJECT_DIR/build_install_test" *>&1
     # Run package test
     - ctest --test-dir "$CI_PROJECT_DIR/build_install_test" -C $CMAKE_BUILD_TYPE --output-on-failure *>&1
 
@@ -680,7 +684,7 @@ test:windows:
       -D CMAKE_CXX_COMPILER=${COMPILER}
       -D CMAKE_C_COMPILER_LAUNCHER=phc_sccache_c
       -D CMAKE_CXX_COMPILER_LAUNCHER=phc_sccache_cxx
-      -D CMAKE_CXX_STANDARD=14
+      -D CMAKE_CXX_STANDARD=17
     - cmake --build ${ROCRAND_STAT_TESTS_DIR}/build
     - mkdir ${LOGS_DIR}
     - cd ${ROCRAND_STAT_TESTS_DIR}/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Documentation for rocRAND is available at
 [https://rocm.docs.amd.com/projects/rocRAND/en/latest/](https://rocm.docs.amd.com/projects/rocRAND/en/latest/)
 
+## (Unreleased) rocRAND-4.x.x for ROCm 7.0.0
+
+### Changed
+
+* Changed return type for `rocrand_generate_poisson` for `SOBOL64` and `SCRAMBLED_SOBOL64` engines
+* Changed unnecessarily large 64-bit data type of constants used for skipping in `MRG32K3A` to 32-bit data type 
+
 ## rocRAND 3.4.0 for ROCm 6.5
 
 ### Added
@@ -34,6 +41,10 @@ Documentation for rocRAND is available at
 ### Fixed
 
 * Fixed an issue where `mt19937.hpp` would cause kernel errors during auto tuning.
+
+### Removed
+
+* Removed C++14 support, only C++17 is supported.
 
 ## rocRAND 3.3.0 for ROCm 6.4
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -134,7 +134,7 @@ if(BUILD_TEST)
     message(STATUS "Google Test not found or force download on. Fetching...")
     option(BUILD_GTEST "Builds the googletest subproject" ON)
     option(BUILD_GMOCK "Builds the googlemock subproject" OFF)
-    option(INSTALL_GTEST "Enable installation of googletest" OFF)
+    option(INSTALL_GTEST "Enable installation of googletest" ON)
     FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git

--- a/library/include/rocrand/rocrand.h
+++ b/library/include/rocrand/rocrand.h
@@ -26,15 +26,16 @@
  *  @{
  */
 
+// IWYU pragma: begin_exports
 #include "rocrand/rocrand_discrete_types.h"
+#include "rocrand/rocrand_version.h"
+// IWYU pragma: end_exports
+
+#include "rocrand/rocrandapi.h"
 
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <hip/hip_vector_types.h>
-
-#include "rocrand/rocrandapi.h"
-
-#include "rocrand/rocrand_version.h"
 
 /// \cond ROCRAND_DOCS_TYPEDEFS
 /// rocRAND random number generator (opaque)

--- a/library/include/rocrand/rocrand.hpp
+++ b/library/include/rocrand/rocrand.hpp
@@ -24,9 +24,12 @@
 // At least C++11 required
 #if defined(__cplusplus) && __cplusplus >= 201103L
 
+    // IWYU pragma: begin_exports
     #include "rocrand/rocrand.h"
     #include "rocrand/rocrand_kernel.h"
+    // IWYU pragma: end_exports
 
+    #include <cassert>
     #include <exception>
     #include <limits>
     #include <random>
@@ -34,9 +37,8 @@
     #include <string>
     #include <type_traits>
 
-    #include <cassert>
-
-namespace rocrand_cpp {
+namespace rocrand_cpp
+{
 
 /// \rocrand_internal \addtogroup rocrandhostcpp
 /// @{

--- a/library/include/rocrand/rocrand_common.h
+++ b/library/include/rocrand/rocrand_common.h
@@ -37,8 +37,6 @@
 
 #include <hip/hip_runtime.h>
 
-#include <math.h>
-
 #define ROCRAND_KERNEL __global__ static
 
 #if __HIP_DEVICE_COMPILE__            \

--- a/library/include/rocrand/rocrand_discrete.h
+++ b/library/include/rocrand/rocrand_discrete.h
@@ -21,8 +21,7 @@
 #ifndef ROCRAND_DISCRETE_H_
 #define ROCRAND_DISCRETE_H_
 
-#include <math.h>
-
+#include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_lfsr113.h"
 #include "rocrand/rocrand_mrg31k3p.h"
 #include "rocrand/rocrand_mrg32k3a.h"
@@ -38,7 +37,9 @@
 #include "rocrand/rocrand_threefry4x64_20.h"
 #include "rocrand/rocrand_xorwow.h"
 
-#include "rocrand/rocrand_discrete_types.h"
+#include <hip/hip_runtime.h>
+
+#include <math.h>
 
 // On certain architectures such as NAVI2 and NAVI3, double arithmetic is significantly slower.
 // In such cases we want to prefer the CDF method over the alias method.

--- a/library/include/rocrand/rocrand_kernel.h
+++ b/library/include/rocrand/rocrand_kernel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 #ifndef ROCRAND_KERNEL_H_
 #define ROCRAND_KERNEL_H_
 
-#include "rocrand/rocrand_common.h"
+// IWYU pragma: begin_exports
 #include "rocrand/rocrand_lfsr113.h"
 #include "rocrand/rocrand_mrg31k3p.h"
 #include "rocrand/rocrand_mrg32k3a.h"
@@ -42,5 +42,6 @@
 #include "rocrand/rocrand_log_normal.h"
 #include "rocrand/rocrand_poisson.h"
 #include "rocrand/rocrand_discrete.h"
+// IWYU pragma: end_exports
 
 #endif // ROCRAND_KERNEL_H_

--- a/library/include/rocrand/rocrand_lfsr113.h
+++ b/library/include/rocrand/rocrand_lfsr113.h
@@ -21,8 +21,9 @@
 #ifndef ROCRAND_LFSR113_H_
 #define ROCRAND_LFSR113_H_
 
-#include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_lfsr113_precomputed.h"
+
+#include <hip/hip_runtime.h>
 
 /** \rocrand_internal \addtogroup rocranddevice
  *

--- a/library/include/rocrand/rocrand_log_normal.h
+++ b/library/include/rocrand/rocrand_log_normal.h
@@ -26,8 +26,6 @@
  *  @{
  */
 
-#include <math.h>
-
 #include "rocrand/rocrand_lfsr113.h"
 #include "rocrand/rocrand_mrg31k3p.h"
 #include "rocrand/rocrand_mrg32k3a.h"
@@ -44,6 +42,10 @@
 #include "rocrand/rocrand_xorwow.h"
 
 #include "rocrand/rocrand_normal.h"
+
+#include <hip/hip_runtime.h>
+
+#include <math.h>
 
 /**
  * \brief Returns a log-normally distributed \p float value.

--- a/library/include/rocrand/rocrand_mrg31k3p.h
+++ b/library/include/rocrand/rocrand_mrg31k3p.h
@@ -24,6 +24,8 @@
 #include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_mrg31k3p_precomputed.h"
 
+#include <hip/hip_runtime.h>
+
 #define ROCRAND_MRG31K3P_M1 2147483647U // 2 ^ 31 - 1
 #define ROCRAND_MRG31K3P_M2 2147462579U // 2 ^ 31 - 21069
 #define ROCRAND_MRG31K3P_MASK12 511U // 2 ^ 9 - 1

--- a/library/include/rocrand/rocrand_mrg32k3a_precomputed.h
+++ b/library/include/rocrand/rocrand_mrg32k3a_precomputed.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,7 @@
 #define MRG323A_DIM 64
 #define MRG323A_N 576
 
-static const __device__ unsigned long long d_A1[MRG323A_N] = {
+static const __device__ unsigned int d_A1[MRG323A_N] = {
     // clang-format off
     0, 1, 0, 0, 0, 1, 4294156359, 1403580, 0, 
     0, 0, 1, 4294156359, 1403580, 0, 0, 4294156359, 1403580, 
@@ -96,7 +96,7 @@ static const __device__ unsigned long long d_A1[MRG323A_N] = {
     // clang-format on
 };
 
-static const unsigned long long h_A1[MRG323A_N] = {
+static const unsigned int h_A1[MRG323A_N] = {
     // clang-format off
     0, 1, 0, 0, 0, 1, 4294156359, 1403580, 0, 
     0, 0, 1, 4294156359, 1403580, 0, 0, 4294156359, 1403580, 
@@ -165,7 +165,7 @@ static const unsigned long long h_A1[MRG323A_N] = {
     // clang-format on
 };
 
-static const __device__ unsigned long long d_A2[MRG323A_N] = {
+static const __device__ unsigned int d_A2[MRG323A_N] = {
     // clang-format off
     0, 1, 0, 0, 0, 1, 4293573854, 0, 527612, 
     0, 0, 1, 4293573854, 0, 527612, 2706407399, 4293573854, 3497978192, 
@@ -234,7 +234,7 @@ static const __device__ unsigned long long d_A2[MRG323A_N] = {
     // clang-format on
 };
 
-static const unsigned long long h_A2[MRG323A_N] = {
+static const unsigned int h_A2[MRG323A_N] = {
     // clang-format off
     0, 1, 0, 0, 0, 1, 4293573854, 0, 527612, 
     0, 0, 1, 4293573854, 0, 527612, 2706407399, 4293573854, 3497978192, 
@@ -303,7 +303,7 @@ static const unsigned long long h_A2[MRG323A_N] = {
     // clang-format on
 };
 
-static const __device__ unsigned long long d_A1P76[MRG323A_N] = {
+static const __device__ unsigned int d_A1P76[MRG323A_N] = {
     // clang-format off
     82758667, 1871391091, 4127413238, 3672831523, 69195019, 1871391091, 3672091415, 3528743235, 69195019, 
     3361372532, 2329303404, 99651939, 2008671965, 2931758910, 2329303404, 1113529483, 2374097189, 2931758910, 
@@ -372,7 +372,7 @@ static const __device__ unsigned long long d_A1P76[MRG323A_N] = {
     // clang-format on
 };
 
-static const unsigned long long h_A1P76[MRG323A_N] = {
+static const unsigned int h_A1P76[MRG323A_N] = {
     // clang-format off
     82758667, 1871391091, 4127413238, 3672831523, 69195019, 1871391091, 3672091415, 3528743235, 69195019, 
     3361372532, 2329303404, 99651939, 2008671965, 2931758910, 2329303404, 1113529483, 2374097189, 2931758910, 
@@ -441,7 +441,7 @@ static const unsigned long long h_A1P76[MRG323A_N] = {
     // clang-format on
 };
 
-static const __device__ unsigned long long d_A2P76[MRG323A_N] = {
+static const __device__ unsigned int d_A2P76[MRG323A_N] = {
     // clang-format off
     1511326704, 3759209742, 1610795712, 4292754251, 1511326704, 3889917532, 3859662829, 4292754251, 3708466080, 
     972103006, 964807713, 878035866, 4248550197, 972103006, 1926628839, 1448629089, 4248550197, 3196114006, 
@@ -510,7 +510,7 @@ static const __device__ unsigned long long d_A2P76[MRG323A_N] = {
     // clang-format on
 };
 
-static const unsigned long long h_A2P76[MRG323A_N] = {
+static const unsigned int h_A2P76[MRG323A_N] = {
     // clang-format off
     1511326704, 3759209742, 1610795712, 4292754251, 1511326704, 3889917532, 3859662829, 4292754251, 3708466080, 
     972103006, 964807713, 878035866, 4248550197, 972103006, 1926628839, 1448629089, 4248550197, 3196114006, 
@@ -579,7 +579,7 @@ static const unsigned long long h_A2P76[MRG323A_N] = {
     // clang-format on
 };
 
-static const __device__ unsigned long long d_A1P127[MRG323A_N] = {
+static const __device__ unsigned int d_A1P127[MRG323A_N] = {
     // clang-format off
     2427906178, 3580155704, 949770784, 226153695, 1230515664, 3580155704, 1988835001, 986791581, 1230515664, 
     1774047142, 3199155377, 3106427820, 1901920839, 4290900039, 3199155377, 4178980191, 280623348, 4290900039, 
@@ -648,7 +648,7 @@ static const __device__ unsigned long long d_A1P127[MRG323A_N] = {
     // clang-format on
 };
 
-static const unsigned long long h_A1P127[MRG323A_N] = {
+static const unsigned int h_A1P127[MRG323A_N] = {
     // clang-format off
     2427906178, 3580155704, 949770784, 226153695, 1230515664, 3580155704, 1988835001, 986791581, 1230515664, 
     1774047142, 3199155377, 3106427820, 1901920839, 4290900039, 3199155377, 4178980191, 280623348, 4290900039, 
@@ -717,7 +717,7 @@ static const unsigned long long h_A1P127[MRG323A_N] = {
     // clang-format on
 };
 
-static const __device__ unsigned long long d_A2P127[MRG323A_N] = {
+static const __device__ unsigned int d_A2P127[MRG323A_N] = {
     // clang-format off
     1464411153, 277697599, 1610723613, 32183930, 1464411153, 1022607788, 2824425944, 32183930, 2093834863, 
     3492361727, 1027004383, 3167429889, 3674905362, 3492361727, 3572939265, 4270409313, 3674905362, 698814233, 
@@ -786,7 +786,7 @@ static const __device__ unsigned long long d_A2P127[MRG323A_N] = {
     // clang-format on
 };
 
-static const unsigned long long h_A2P127[MRG323A_N] = {
+static const unsigned int h_A2P127[MRG323A_N] = {
     // clang-format off
     1464411153, 277697599, 1610723613, 32183930, 1464411153, 1022607788, 2824425944, 32183930, 2093834863, 
     3492361727, 1027004383, 3167429889, 3674905362, 3492361727, 3572939265, 4270409313, 3674905362, 698814233, 

--- a/library/include/rocrand/rocrand_mtgp32.h
+++ b/library/include/rocrand/rocrand_mtgp32.h
@@ -55,10 +55,11 @@
 #ifndef ROCRAND_MTGP32_H_
 #define ROCRAND_MTGP32_H_
 
-#include <stdlib.h>
-
 #include "rocrand/rocrand.h"
-#include "rocrand/rocrand_common.h"
+
+#include <hip/hip_runtime.h>
+
+#include <stdlib.h>
 
 #define MTGP_MEXP 11213
 #define MTGP_N 351

--- a/library/include/rocrand/rocrand_mtgp32_11213.h
+++ b/library/include/rocrand/rocrand_mtgp32_11213.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -57,8 +57,9 @@
 #ifndef ROCRAND_MTGP32_11213_H_
 #define ROCRAND_MTGP32_11213_H_
 
-#include <stdint.h>
 #include "rocrand/rocrand_mtgp32.h"
+
+#include <stdint.h>
 
 static rocrand_device::mtgp32_fast_params mtgp32dc_params_fast_11213[]
  = {

--- a/library/include/rocrand/rocrand_normal.h
+++ b/library/include/rocrand/rocrand_normal.h
@@ -26,8 +26,6 @@
  *  @{
  */
 
-#include <math.h>
-
 #include "rocrand/rocrand_lfsr113.h"
 #include "rocrand/rocrand_mrg31k3p.h"
 #include "rocrand/rocrand_mrg32k3a.h"
@@ -44,6 +42,10 @@
 #include "rocrand/rocrand_xorwow.h"
 
 #include "rocrand/rocrand_uniform.h"
+
+#include <hip/hip_runtime.h>
+
+#include <math.h>
 
 namespace rocrand_device {
 namespace detail {

--- a/library/include/rocrand/rocrand_philox4x32_10.h
+++ b/library/include/rocrand/rocrand_philox4x32_10.h
@@ -55,12 +55,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rocrand/rocrand_common.h"
 
+#include <hip/hip_runtime.h>
+
 // Constants from Random123
 // See https://www.deshawresearch.com/resources_random123.html
 #define ROCRAND_PHILOX_M4x32_0 0xD2511F53U
 #define ROCRAND_PHILOX_M4x32_1 0xCD9E8D57U
-#define ROCRAND_PHILOX_W32_0   0x9E3779B9U
-#define ROCRAND_PHILOX_W32_1   0xBB67AE85U
+#define ROCRAND_PHILOX_W32_0 0x9E3779B9U
+#define ROCRAND_PHILOX_W32_1 0xBB67AE85U
 
 /** \rocrand_internal \addtogroup rocranddevice
  *
@@ -422,6 +424,6 @@ void skipahead_sequence(unsigned long long sequence, rocrand_state_philox4x32_10
     return state->discard_subsequence(sequence);
 }
 
-#endif // ROCRAND_PHILOX4X32_10_H_
-
 /** @} */ // end of group rocranddevice
+
+#endif // ROCRAND_PHILOX4X32_10_H_

--- a/library/include/rocrand/rocrand_poisson.h
+++ b/library/include/rocrand/rocrand_poisson.h
@@ -46,6 +46,8 @@
 #include "rocrand/rocrand_normal.h"
 #include "rocrand/rocrand_uniform.h"
 
+#include <hip/hip_runtime.h>
+
 namespace rocrand_device {
 namespace detail {
 
@@ -389,39 +391,40 @@ unsigned int rocrand_poisson(rocrand_state_scrambled_sobol32* state, double lamb
 }
 
 /**
- * \brief Returns a Poisson-distributed <tt>unsigned long long int</tt> using SOBOL64 generator.
+ * \brief Returns a Poisson-distributed <tt>unsigned int</tt> using SOBOL64 generator.
  *
- * Generates and returns Poisson-distributed distributed random <tt>unsigned long long int</tt>
+ * Generates and returns Poisson-distributed distributed random <tt>unsigned int</tt>
  * values using SOBOL64 generator in \p state. State is incremented by one position.
  *
  * \param state Pointer to a state to use
  * \param lambda Lambda parameter of the Poisson distribution
  *
- * \return Poisson-distributed <tt>unsigned long long int</tt>
+ * \return Poisson-distributed <tt>unsigned int</tt>
  */
 __forceinline__ __device__ __host__
-unsigned long long int rocrand_poisson(rocrand_state_sobol64* state, double lambda)
+unsigned int rocrand_poisson(rocrand_state_sobol64* state, double lambda)
 {
-    return rocrand_device::detail::poisson_distribution_inv<rocrand_state_sobol64*,
-                                                            unsigned long long int>(state, lambda);
+    return rocrand_device::detail::poisson_distribution_inv<rocrand_state_sobol64*, unsigned int>(
+        state,
+        lambda);
 }
 
 /**
- * \brief Returns a Poisson-distributed <tt>unsigned long long int</tt> using SCRAMBLED_SOBOL64 generator.
+ * \brief Returns a Poisson-distributed <tt>unsigned int</tt> using SCRAMBLED_SOBOL64 generator.
  *
- * Generates and returns Poisson-distributed distributed random <tt>unsigned long long int</tt>
+ * Generates and returns Poisson-distributed distributed random <tt>unsigned int</tt>
  * values using SCRAMBLED_SOBOL64 generator in \p state. State is incremented by one position.
  *
  * \param state Pointer to a state to use
  * \param lambda Lambda parameter of the Poisson distribution
  *
- * \return Poisson-distributed <tt>unsigned long long int</tt>
+ * \return Poisson-distributed <tt>unsigned int</tt>
  */
 __forceinline__ __device__ __host__
-unsigned long long int rocrand_poisson(rocrand_state_scrambled_sobol64* state, double lambda)
+unsigned int rocrand_poisson(rocrand_state_scrambled_sobol64* state, double lambda)
 {
     return rocrand_device::detail::poisson_distribution_inv<rocrand_state_scrambled_sobol64*,
-                                                            unsigned long long int>(state, lambda);
+                                                            unsigned int>(state, lambda);
 }
 
 /**

--- a/library/include/rocrand/rocrand_scrambled_sobol32.h
+++ b/library/include/rocrand/rocrand_scrambled_sobol32.h
@@ -21,8 +21,9 @@
 #ifndef ROCRAND_SCRAMBLED_SOBOL32_H_
 #define ROCRAND_SCRAMBLED_SOBOL32_H_
 
-#include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_sobol32.h"
+
+#include <hip/hip_runtime.h>
 
 namespace rocrand_device
 {

--- a/library/include/rocrand/rocrand_scrambled_sobol64.h
+++ b/library/include/rocrand/rocrand_scrambled_sobol64.h
@@ -21,8 +21,9 @@
 #ifndef ROCRAND_SCRAMBLED_SOBOL64_H_
 #define ROCRAND_SCRAMBLED_SOBOL64_H_
 
-#include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_sobol64.h"
+
+#include <hip/hip_runtime.h>
 
 namespace rocrand_device
 {

--- a/library/include/rocrand/rocrand_sobol32.h
+++ b/library/include/rocrand/rocrand_sobol32.h
@@ -21,7 +21,7 @@
 #ifndef ROCRAND_SOBOL32_H_
 #define ROCRAND_SOBOL32_H_
 
-#include "rocrand/rocrand_common.h"
+#include <hip/hip_runtime.h>
 
 namespace rocrand_device {
 

--- a/library/include/rocrand/rocrand_sobol64.h
+++ b/library/include/rocrand/rocrand_sobol64.h
@@ -21,7 +21,7 @@
 #ifndef ROCRAND_SOBOL64_H_
 #define ROCRAND_SOBOL64_H_
 
-#include "rocrand/rocrand_common.h"
+#include <hip/hip_runtime.h>
 
 namespace rocrand_device {
 

--- a/library/include/rocrand/rocrand_threefry2_impl.h
+++ b/library/include/rocrand/rocrand_threefry2_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,8 +53,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ROCRAND_THREEFRY2_IMPL_H_
 #define ROCRAND_THREEFRY2_IMPL_H_
 
+#include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_threefry_common.h"
-#include <rocrand/rocrand_common.h>
+
+#include <hip/hip_runtime.h>
 
 #ifndef THREEFRY2x32_DEFAULT_ROUNDS
     #define THREEFRY2x32_DEFAULT_ROUNDS 20

--- a/library/include/rocrand/rocrand_threefry2x32_20.h
+++ b/library/include/rocrand/rocrand_threefry2x32_20.h
@@ -55,6 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rocrand/rocrand_threefry2_impl.h"
 
+#include <hip/hip_runtime.h>
+
 namespace rocrand_device
 {
 

--- a/library/include/rocrand/rocrand_threefry2x64_20.h
+++ b/library/include/rocrand/rocrand_threefry2x64_20.h
@@ -55,6 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rocrand/rocrand_threefry2_impl.h"
 
+#include <hip/hip_runtime.h>
+
 namespace rocrand_device
 {
 

--- a/library/include/rocrand/rocrand_threefry4_impl.h
+++ b/library/include/rocrand/rocrand_threefry4_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,8 +53,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ROCRAND_THREEFRY4_IMPL_H_
 #define ROCRAND_THREEFRY4_IMPL_H_
 
+#include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_threefry_common.h"
-#include <rocrand/rocrand_common.h>
+
+#include <hip/hip_runtime.h>
 
 #ifndef THREEFRY4x32_DEFAULT_ROUNDS
     #define THREEFRY4x32_DEFAULT_ROUNDS 20

--- a/library/include/rocrand/rocrand_threefry4x32_20.h
+++ b/library/include/rocrand/rocrand_threefry4x32_20.h
@@ -55,6 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rocrand/rocrand_threefry4_impl.h"
 
+#include <hip/hip_runtime.h>
+
 namespace rocrand_device
 {
 

--- a/library/include/rocrand/rocrand_threefry4x64_20.h
+++ b/library/include/rocrand/rocrand_threefry4x64_20.h
@@ -55,6 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rocrand/rocrand_threefry4_impl.h"
 
+#include <hip/hip_runtime.h>
+
 namespace rocrand_device
 {
 

--- a/library/include/rocrand/rocrand_threefry_common.h
+++ b/library/include/rocrand/rocrand_threefry_common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ROCRAND_THREEFRY_COMMON_H_
 #define ROCRAND_THREEFRY_COMMON_H_
 
-#include "rocrand/rocrand_common.h"
+#include <hip/hip_runtime.h>
 
 // C240 constant for Skein Hash function Threefish
 #define SKEIN_MK_64(hi32, lo32) ((lo32) + (((unsigned long long)(hi32)) << 32))

--- a/library/include/rocrand/rocrand_uniform.h
+++ b/library/include/rocrand/rocrand_uniform.h
@@ -43,6 +43,8 @@
 
 #include "rocrand/rocrand_common.h"
 
+#include <hip/hip_runtime.h>
+
 namespace rocrand_device {
 namespace detail {
 

--- a/library/include/rocrand/rocrand_xorwow.h
+++ b/library/include/rocrand/rocrand_xorwow.h
@@ -24,6 +24,8 @@
 #include "rocrand/rocrand_common.h"
 #include "rocrand/rocrand_xorwow_precomputed.h"
 
+#include <hip/hip_runtime.h>
+
 /** \rocrand_internal \addtogroup rocranddevice
  *
  *  @{
@@ -310,6 +312,6 @@ void skipahead_sequence(unsigned long long sequence, rocrand_state_xorwow* state
     return state->discard_subsequence(sequence);
 }
 
-#endif // ROCRAND_XORWOW_H_
-
 /** @} */ // end of group rocranddevice
+
+#endif // ROCRAND_XORWOW_H_

--- a/library/src/rng/common.hpp
+++ b/library/src/rng/common.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 
 #include <rocrand/rocrand_common.h>
 
-#include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 
 #include <cstdio>

--- a/library/src/rng/distribution/discrete.hpp
+++ b/library/src/rng/distribution/discrete.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +21,13 @@
 #ifndef ROCRAND_RNG_DISTRIBUTION_DISCRETE_H_
 #define ROCRAND_RNG_DISTRIBUTION_DISCRETE_H_
 
-#include "../common.hpp"
+#include "../common.hpp" // IWYU pragma: keep
 
 #include <rocrand/rocrand.h>
 #include <rocrand/rocrand_discrete.h>
 #include <rocrand/rocrand_discrete_types.h>
 
 #include <algorithm>
-#include <climits>
 #include <iterator>
 #include <vector>
 

--- a/library/src/rng/distribution/log_normal.hpp
+++ b/library/src/rng/distribution/log_normal.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 #ifndef ROCRAND_RNG_DISTRIBUTION_LOG_NORMAL_H_
 #define ROCRAND_RNG_DISTRIBUTION_LOG_NORMAL_H_
 
-#include "../common.hpp"
+#include "../common.hpp" // IWYU pragma: keep
 
 #include <rocrand/rocrand.h>
 #include <rocrand/rocrand_log_normal.h>

--- a/library/src/rng/distribution/normal.hpp
+++ b/library/src/rng/distribution/normal.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +21,12 @@
 #ifndef ROCRAND_RNG_DISTRIBUTION_NORMAL_H_
 #define ROCRAND_RNG_DISTRIBUTION_NORMAL_H_
 
-#include "../common.hpp"
+#include "../common.hpp" // IWYU pragma: keep
 
 #include <rocrand/rocrand.h>
 #include <rocrand/rocrand_normal.h>
 
-#include <hip/hip_runtime.h>
-
-#include <math.h>
+#include <hip/hip_runtime_api.h>
 
 namespace rocrand_impl::host
 {

--- a/library/src/rng/distribution/poisson.hpp
+++ b/library/src/rng/distribution/poisson.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,8 @@
 #ifndef ROCRAND_RNG_DISTRIBUTION_POISSON_H_
 #define ROCRAND_RNG_DISTRIBUTION_POISSON_H_
 
+#include "../common.hpp" // IWYU pragma: keep
+
 #include "../system.hpp"
 #include "discrete.hpp"
 
@@ -29,12 +31,11 @@
 #include <rocrand/rocrand_poisson.h>
 #include <rocrand/rocrand_uniform.h>
 
-#include <algorithm>
+#include <hip/hip_runtime_api.h>
+
 #include <cassert>
-#include <climits>
 #include <memory>
 #include <mutex>
-#include <utility>
 #include <variant>
 #include <vector>
 

--- a/library/src/rng/distribution/uniform.hpp
+++ b/library/src/rng/distribution/uniform.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,13 +21,11 @@
 #ifndef ROCRAND_RNG_DISTRIBUTION_UNIFORM_H_
 #define ROCRAND_RNG_DISTRIBUTION_UNIFORM_H_
 
-#include "../common.hpp"
+#include "../common.hpp" // IWYU pragma: keep
 
 #include <rocrand/rocrand_uniform.h>
 
-#include <hip/hip_runtime.h>
-
-#include <math.h>
+#include <hip/hip_runtime_api.h>
 
 // Universal
 

--- a/library/src/rng/distributions.hpp
+++ b/library/src/rng/distributions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,10 +21,12 @@
 #ifndef ROCRAND_RNG_DISTRIBUTIONS_H_
 #define ROCRAND_RNG_DISTRIBUTIONS_H_
 
+// IWYU pragma: begin_exports
 #include "distribution/uniform.hpp"
 #include "distribution/normal.hpp"
 #include "distribution/log_normal.hpp"
 #include "distribution/discrete.hpp"
 #include "distribution/poisson.hpp"
+// IWYU pragma: end_exports
 
 #endif // ROCRAND_RNG_DISTRIBUTION_S_H_

--- a/library/src/rng/generator_type.hpp
+++ b/library/src/rng/generator_type.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,9 +21,10 @@
 #ifndef ROCRAND_RNG_GENERATOR_TYPE_H_
 #define ROCRAND_RNG_GENERATOR_TYPE_H_
 
-#include <hip/hip_runtime.h>
-#include <hip/hip_vector_types.h>
 #include <rocrand/rocrand.h>
+
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_vector_types.h>
 
 struct rocrand_generator_base_type
 {

--- a/library/src/rng/lfsr113.hpp
+++ b/library/src/rng/lfsr113.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,9 @@
 #ifndef ROCRAND_RNG_LFSR113_H_
 #define ROCRAND_RNG_LFSR113_H_
 
+// IWYU pragma: begin_keep
 #include "config/lfsr113_config.hpp"
+// IWYU pragma: end_keep
 
 #include "common.hpp"
 #include "config_types.hpp"

--- a/library/src/rng/mrg.hpp
+++ b/library/src/rng/mrg.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,8 +21,10 @@
 #ifndef ROCRAND_RNG_MRG_H_
 #define ROCRAND_RNG_MRG_H_
 
+// IWYU pragma: begin_keep
 #include "config/mrg31k3p_config.hpp"
 #include "config/mrg32k3a_config.hpp"
+// IWYU pragma: end_keep
 
 #include "common.hpp"
 #include "config_types.hpp"

--- a/library/src/rng/mt19937.hpp
+++ b/library/src/rng/mt19937.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,10 @@
 
 #ifndef ROCRAND_RNG_MT19937_H_
 #define ROCRAND_RNG_MT19937_H_
+
+// IWYU pragma: begin_keep
 #include "config/mt19937_config.hpp"
+// IWYU pragma: end_keep
 
 #include "common.hpp"
 #include "config_types.hpp"
@@ -59,9 +62,6 @@
 #include "mt19937_octo_engine.hpp"
 #include "system.hpp"
 #include "utils/cpp_utils.hpp"
-
-#include "config/config_defaults.hpp"
-#include "config_types.hpp"
 
 #include <rocrand/rocrand.h>
 #include <rocrand/rocrand_mt19937_precomputed.h>

--- a/library/src/rng/mtgp32.hpp
+++ b/library/src/rng/mtgp32.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -55,9 +55,11 @@
 #ifndef ROCRAND_RNG_MTGP32_H_
 #define ROCRAND_RNG_MTGP32_H_
 
-#include "common.hpp"
-#include "config/config_defaults.hpp"
+// IWYU pragma: begin_keep
 #include "config/mtgp32_config.hpp"
+// IWYU pragma: end_keep
+
+#include "common.hpp"
 #include "config_types.hpp"
 #include "distributions.hpp"
 #include "generator_type.hpp"

--- a/library/src/rng/philox4x32_10.hpp
+++ b/library/src/rng/philox4x32_10.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,7 +53,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ROCRAND_RNG_PHILOX4X32_10_H_
 #define ROCRAND_RNG_PHILOX4X32_10_H_
 
+// IWYU pragma: begin_keep
 #include "config/philox4_32_10_config.hpp"
+// IWYU pragma: end_keep
 
 #include "common.hpp"
 #include "config_types.hpp"

--- a/library/src/rng/threefry.hpp
+++ b/library/src/rng/threefry.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,10 +21,12 @@
 #ifndef ROCRAND_RNG_THREEFRY_H_
 #define ROCRAND_RNG_THREEFRY_H_
 
+// IWYU pragma: begin_keep
 #include "config/threefry2_32_20_config.hpp"
 #include "config/threefry2_64_20_config.hpp"
 #include "config/threefry4_32_20_config.hpp"
 #include "config/threefry4_64_20_config.hpp"
+// IWYU pragma: end_keep
 
 #include "common.hpp"
 #include "config_types.hpp"

--- a/library/src/rng/utils/cpp_utils.hpp
+++ b/library/src/rng/utils/cpp_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,13 +26,11 @@
 
 #include "unreachable.hpp"
 
-#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 
 #include <array>
-#include <limits>
 #include <tuple>
 #include <type_traits>
-#include <utility>
 
 #include <cassert>
 #include <cstddef>

--- a/library/src/rng/xorwow.hpp
+++ b/library/src/rng/xorwow.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,9 @@
 #ifndef ROCRAND_RNG_XORWOW_H_
 #define ROCRAND_RNG_XORWOW_H_
 
+// IWYU pragma: begin_keep
 #include "config/xorwow_config.hpp"
+// IWYU pragma: end_keep
 
 #include "common.hpp"
 #include "config_types.hpp"

--- a/test/cpp_wrapper/CMakeLists.txt
+++ b/test/cpp_wrapper/CMakeLists.txt
@@ -39,10 +39,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 
-if (CMAKE_CXX_STANDARD EQUAL 14)
-  message(WARNING "C++14 will be deprecated in the next major release")
-elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
-  message(FATAL_ERROR "Only C++14 and C++17 are supported")
+if(NOT CMAKE_CXX_STANDARD EQUAL 17)
+  message(FATAL_ERROR "Only C++17 is supported")
 endif()
 
 include(cmake/Dependencies.cmake)

--- a/test/package/CMakeLists.txt
+++ b/test/package/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,10 +52,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 
-if (CMAKE_CXX_STANDARD EQUAL 14)
-  message(WARNING "C++14 will be deprecated in the next major release")
-elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
-  message(FATAL_ERROR "Only C++14 and C++17 are supported")
+if(NOT CMAKE_CXX_STANDARD EQUAL 17)
+  message(FATAL_ERROR "Only C++17 is supported")
 endif()
 
 # Find rocRAND

--- a/test/parity/CMakeLists.txt
+++ b/test/parity/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,10 +62,8 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if (CMAKE_CXX_STANDARD EQUAL 14)
-  message(WARNING "C++14 will be deprecated in the next major release")
-elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
-  message(FATAL_ERROR "Only C++14 and C++17 are supported")
+if(NOT CMAKE_CXX_STANDARD EQUAL 17)
+  message(FATAL_ERROR "Only C++17 is supported")
 endif()
 
 # Find rocRAND

--- a/test/test_rocrand_cpp_wrapper.cpp
+++ b/test/test_rocrand_cpp_wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 #include "test_common.hpp"
-#include "test_rocrand_common.hpp"
 #include "test_utils/rocrand_cpp_wrapper_traits.hpp"
 #include "test_utils/test_matrix.hpp"
 

--- a/test/test_rocrand_host.cpp
+++ b/test/test_rocrand_host.cpp
@@ -25,7 +25,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <iomanip>
 #include <random>
 #include <vector>
 

--- a/test/test_rocrand_kernel_lfsr113.cpp
+++ b/test/test_rocrand_kernel_lfsr113.cpp
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <cmath>
-#include <type_traits>
 #include <vector>
 
 #include <hip/hip_runtime.h>

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -25,7 +25,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ ")
 


### PR DESCRIPTION
Changes:

- 7.0 Breaking Changes, https://github.com/ROCm/rocRAND/commit/ca3f32b39f863a98531171587da878e181680d63
  * Remove unnecessarily large constants for MRG32K3a
  * Remove unnecessary includes from public headers
  * Add include-what-you-use (IWYU) pragmas
  * Fix SCRAMBLED_SOBOL64 and SOBOL64 return value for Poisson distribution
  * Remove C++14 support
  * Fix CI failures