### PR TITLE
Cherry-pick to release/rocm-rel-6.4: First phase of rocRAND docs refresh (#625)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ set(ROCRAND_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDI
 
 rocm_create_package(
     NAME ${package_name}
-    DESCRIPTION "Radeon Open Compute RAND library"
+    DESCRIPTION "rocRAND is a ROCm random number generation library"
     MAINTAINER "rocRAND Maintainer <hiprand-maintainer@amd.com>"
     LDCONFIG
     # LDCONFIG_DIR ${ROCRAND_CONFIG_DIR}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. meta::
-  :description: rocRAND documentation and API reference library
+  :description: introduction to the rocRAND documentation and API reference library
   :keywords: rocRAND, ROCm, API, documentation
 
 .. _rocrand-docs-home:
@@ -8,32 +8,35 @@
 rocRAND documentation
 ********************************************************************
 
-rocRAND provides functions that generate pseudo-random and quasi-random numbers. The rocRAND library is implemented in the `HIP <https://rocm.docs.amd.com/projects/HIP/en/latest/index.html>`_
-programming language and optimized for AMD's latest discrete GPUs. It is designed to run on top
-of AMD's `ROCm <https://rocm.docs.amd.com/en/latest/>`_, but it also works on NVIDIA CUDA-enabled GPUs.
+rocRAND provides functions that generate pseudo-random and quasi-random numbers.
+The rocRAND library is implemented in the :doc:`HIP <hip:index>`
+programming language and optimized for the latest discrete AMD GPUs. It is designed to run on top
+of the AMD :doc:`ROCm platform <rocm:what-is-rocm>`, but it also works on NVIDIA CUDA-enabled GPUs.
 
-rocRAND includes a wrapper library called hipRAND, which you can use to easily port
-NVIDIA CUDA applications using the CUDA cuRAND library to the
-`HIP <https://rocm.docs.amd.com/projects/HIP/en/latest/index.html>`_ layer. In the
-`ROCm <https://rocm.docs.amd.com/en/latest/>`_ environment, hipRAND uses rocRAND.
+rocRAND integrates with a wrapper library called hipRAND, which you can use to easily port
+NVIDIA CUDA applications that use the CUDA cuRAND library to the
+:doc:`HIP <hip:index>` layer. In a
+ROCm environment, hipRAND uses the rocRAND library.
 
-You can access rocRAND code on our `GitHub repository <https://github.com/ROCm/rocRAND>`_.
-
-The documentation is structured as follows:
+The rocRAND public repository is located at `<https://github.com/ROCm/rocRAND>`_.
 
 .. grid:: 2
   :gutter: 3
 
   .. grid-item-card:: Install
 
-    * :ref:`installing`
+    * :doc:`Installation guide <./install/installing>`
 
   .. grid-item-card:: Conceptual
 
-    * :ref:`programmers-guide`
+    * :doc:`Programming guide <./conceptual/programmers-guide>`
 
     * :ref:`curand-compatibility`
     * :ref:`dynamic-ordering-configuration`
+
+  .. grid-item-card:: Examples
+
+    * `Examples <https://github.com/ROCm/rocRAND/tree/develop/python/rocrand/examples>`_
 
   .. grid-item-card:: API reference
 
@@ -43,7 +46,6 @@ The documentation is structured as follows:
     * :doc:`Fortran API reference <fortran-api-reference>`
     * :doc:`API library <doxygen/html/index>`
 
-To contribute to the documentation, refer to
-`Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
+To contribute to the documentation, see `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.

--- a/docs/install/installing.rst
+++ b/docs/install/installing.rst
@@ -1,88 +1,180 @@
 .. meta::
-   :description: rocRAND documentation and API reference library
-   :keywords: rocRAND, ROCm, API, documentation
+   :description: rocRAND installation guide
+   :keywords: rocRAND, ROCm, API, documentation, installation
 
 .. _installing:
 
-============
-Installation
-============
+*******************************************************************
+Installing and building rocRAND
+*******************************************************************
 
-Introduction
-------------
-
-This chapter describes how to obtain rocRAND. There are two main methods: the easiest way is to install the prebuilt packages from the ROCm repositories. Alternatively, this chapter also describes how to build rocRAND from source.
-
-Prebuilt packages
------------------
-
-Installing the prebuilt rocRAND packages requires a ROCm-enabled platform. See the `ROCm documentation <https://rocm.docs.amd.com/>`_ for more information. After installing ROCm or enabling the ROCm repositories, rocRAND can be obtained using the system package manager.
-
-For Ubuntu and Debian::
-
-    sudo apt-get install rocrand
-
-For CentOS::
-
-    sudo yum install rocrand
-
-For SLES::
-
-    sudo dnf install rocrand
-
-This will install rocRAND into the ``/opt/rocm`` directory.
-
-Building rocRAND from source
-----------------------------
-
-Obtaining sources
-^^^^^^^^^^^^^^^^^
-
-The rocRAND sources are available from the `rocRAND GitHub Repository <https://github.com/ROCm/rocRAND>`_. Use the branch that matches the system-installed version of ROCm. For example on a system that has ROCm 5.3 installed, use the following command to obtain rocRAND sources::
-
-    git checkout -b rocm-5.3 https://github.com/ROCmSoftwarePlatform/rocRAND.git
-
-Building the library
-^^^^^^^^^^^^^^^^^^^^
-
-After obtaining the sources, rocRAND can be built using the installation script::
-
-    cd rocRAND
-    ./install --install
-
-This automatically builds all required dependencies, excluding HIP and Git, and installs the project to ``/opt/rocm`` if everything went well. See ``./install --help`` for further information.
-
-Building with CMake
-^^^^^^^^^^^^^^^^^^^
-
-For a more elaborate installation process, rocRAND can be built manually using CMake. This enables certain configuration options that are not exposed to the ``./install`` script. In general, rocRAND can be built using CMake by configuring as follows::
-
-    cd rocrand; mkdir build; cd build
-    # Configure the project
-    CXX=<compiler> cmake [options] ..
-    # Build
-    make -j4
-    # Optionally, run the tests
-    ctest --output-on-failure
-    # Install
-    [sudo] make install
-
-To build for the ROCm platform,``<compiler>`` should be set to ``hipcc``. When building for CUDA ``<compiler>`` should be set to the host compiler. If building for CUDA, then the location of ``nvcc`` may need to be passed explicitly using ``-DCMAKE_CUDA_COMPILER=<path-to-nvcc>`` if it is not on the path. Additionally, the directory where FindHIP.cmake is installed needs to be passed explicitly using ``-DCMAKE_MODULE_PATH``. By default, this file is installed in ``/opt/rocm/hip/cmake``.
-
-The following configuration options are available, in addition to the built-in CMake options:
-
-* ``BUILD_FORTRAN_WRAPPER`` controls whether to build the Fortran wrapper. Defaults to ``OFF``.
-* ``BUILD_TEST`` controls whether to build the rocRAND tests. Defaults to ``OFF``.
-* ``BUILD_BENCHMARK`` controls whether to build the rocRAND benchmarks. Defaults to ``OFF``.
-* ``BUILD_ADDRESS_SANITIZER`` controls whether to build with address sanitization enabled. Defaults to ``OFF``.
-
-To install rocRAND with a non-standard installation location of ROCm, pass ``-DCMAKE_PREFIX_PATH=</path/to/opt/rocm/>`` or set the environment variable ``ROCM_PATH`` to ``path/to/opt/rocm``.
-
-Building the Python API wrapper
--------------------------------
+This topic describes how to install or build rocRAND. The easiest method is to install the prebuilt
+packages from the ROCm repositories, but this chapter also describes how to build rocRAND from source.
 
 Requirements
-^^^^^^^^^^^^
+===============================
+
+rocRAND has the following prerequisites:
+
+*  CMake (version 3.16 or later)
+*  C++ compiler with C++17 support to build the library
+
+   *  gcc version 9 or later is recommended
+   *  Clang uses the development headers and libraries from gcc, so a recent version of it must still be installed when compiling with clang
+
+*  C++ compiler with C++11 support to use the library
+
+*  (Optional) Fortran compiler (This is only required for the Fortran wrapper. GFortran is recommended.)
+
+*  (Optional) GoogleTest (This is only required to build and use the tests. Building the tests is enabled by default.)
+
+   Use ``GTEST_ROOT`` to specify the GoogleTest location. For more information,
+   see `FindGTest <https://cmake.org/cmake/help/latest/module/FindGTest.html>`_.
+   
+   .. note::
+
+      If GoogleTest is not already installed, it will be automatically downloaded and built.
+
+The following additional components are required to use rocRAND on AMD platforms:
+
+*  ROCm (see the :doc:`ROCm installation guide <rocm-install-on-linux:install/quick-start>`)
+*  A HIP-clang compiler, which must be set as the C++ compiler on the ROCm platform.
+
+The following additional components are required to use rocRAND on NVIDIA CUDA platforms:
+
+*  HIP
+*  The latest CUDA SDK
+
+Install using prebuilt packages
+===============================
+
+To install the prebuilt rocRAND packages, you require a ROCm-enabled platform.
+For information on installing ROCm, see the :doc:`ROCm installation guide <rocm-install-on-linux:install/quick-start>`.
+After installing ROCm or enabling the ROCm repositories, use the system package manager to install rocRAND.
+
+For Ubuntu and Debian:
+
+.. code-block:: shell
+
+   sudo apt-get install rocrand
+
+For CentOS-based systems:
+
+.. code-block:: shell
+
+   sudo yum install rocrand
+
+For SLES:
+
+.. code-block:: shell
+
+   sudo dnf install rocrand
+
+These commands install rocRAND in the ``/opt/rocm`` directory.
+
+Build rocRAND from source
+===============================
+
+This section provides the information required to build rocRAND from source.
+
+
+Obtaining the rocRAND source code
+---------------------------------
+
+The rocRAND source code is available from the `rocRAND GitHub Repository <https://github.com/ROCm/rocRAND>`_.
+Use the branch that matches the ROCm version installed on the system.
+For example, on a system with ROCm 6.3 installed, use the following command to obtain the rocRAND version 6.3 source code:
+
+.. code-block:: shell
+
+
+   git checkout -b rocm-6.3 https://github.com/ROCmSoftwarePlatform/rocRAND.git
+
+Building the library
+--------------------
+
+After downloading the source code, use the installation script to build rocRAND:
+
+.. code-block:: shell
+
+   cd rocRAND
+   ./install --install
+
+This automatically builds all required dependencies, excluding HIP and Git, and installs the project
+to ``/opt/rocm``. For further information, run the ``./install --help`` command.
+
+Building with CMake
+--------------------
+
+For a more detailed installation process, build rocRAND manually using CMake.
+This enables certain configuration options that are not available through the ``./install`` script.
+To build rocRAND, use CMake with the following configuration:
+
+.. code-block:: shell
+
+   cd rocrand; mkdir build; cd build
+   # Configure the project
+   CXX=<compiler> cmake [options] ..
+   # Build
+   make -j4
+   # Optionally, run the tests
+   ctest --output-on-failure
+   # Install
+   [sudo] make install
+
+To build for the ROCm platform, ``<compiler>`` should be set to ``hipcc``. To build for CUDA,
+``<compiler>`` should be set to the host compiler. For CUDA, if the location of ``nvcc`` isn't on the path, it might need to be
+passed explicitly using ``-DCMAKE_CUDA_COMPILER=<path-to-nvcc>``.
+Additionally, the directory where ``FindHIP.cmake`` is installed needs to be passed explicitly
+using ``-DCMAKE_MODULE_PATH``. By default, this file is installed in ``/opt/rocm/hip/cmake``.
+
+In addition to the built-in CMake options, the following configuration options are available:
+
+* ``BUILD_FORTRAN_WRAPPER``: Controls whether to build the Fortran wrapper. Defaults to ``OFF``.
+* ``BUILD_TEST``: Controls whether to build the rocRAND tests. Defaults to ``OFF``.
+* ``BUILD_BENCHMARK``: Controls whether to build the rocRAND benchmarks. Defaults to ``OFF``.
+* ``BUILD_ADDRESS_SANITIZER`` Controls whether to build with address sanitization enabled. Defaults to ``OFF``.
+
+To install rocRAND with a non-standard installation location of ROCm, pass ``-DCMAKE_PREFIX_PATH=</path/to/opt/rocm/>``
+or set the environment variable ``ROCM_PATH`` to ``path/to/opt/rocm``.
+
+rocRAND with HIP on Windows
+===============================
+
+rocRAND with HIP on Microsoft Windows has the following additional prerequisites:
+
+*  Python 3.6 or higher (Only required for the install script)
+*  Visual Studio 2019 with Clang support
+*  Strawberry Perl
+
+
+To install support for rocRAND and HIP on Windows, use the ``rmake.py`` Python script as follows:
+
+.. code-block:: shell
+
+   git clone https://github.com/ROCm/rocRAND.git
+   cd rocRAND
+
+   # the -i option will install rocRAND to C:\hipSDK by default
+   python rmake.py -i
+
+   # the -c option will build all clients including unit tests
+   python rmake.py -c
+
+Any existing GoogleTest library in the system (especially static GoogleTest libraries built with other compilers)
+might cause a build failure. If you encounter errors with the existing GoogleTest library or other dependencies,
+pass the ``DEPENDENCIES_FORCE_DOWNLOAD`` flag to CMake to help solve the problem.
+
+To disable inline assembly optimizations in rocRAND for both the host library and the device functions provided in ``rocrand_kernel.h``,
+set the CMake option ``ENABLE_INLINE_ASM`` to ``OFF``.
+
+Building the Python API wrapper
+===============================
+
+This section provides the information required to build the rocRAND Python API wrapper.
+
+Requirements
+--------------------
 
 The rocRAND Python API Wrapper requires the following dependencies:
 
@@ -90,21 +182,30 @@ The rocRAND Python API Wrapper requires the following dependencies:
 * Python 3.5
 * NumPy (will be installed automatically as a dependency if necessary)
 
-Note: If rocRAND is built from sources but not installed or installed in
-non-standard directory, set the ``ROCRAND_PATH`` environment variable. For example::
+.. note::
 
-    export ROCRAND_PATH=~/rocRAND/build/library/
+   If rocRAND is built from source but is either not installed or installed in a
+   non-standard directory, set the ``ROCRAND_PATH`` environment variable
+   to the library location. For example:
 
-Installing
-^^^^^^^^^^
+   .. code-block:: shell
 
-The Python rocRAND module can be installed using pip::
+      export ROCRAND_PATH=~/rocRAND/build/library/
 
-    cd rocrand/python/rocrand
-    pip install .
+Installation
+--------------------
 
-The tests can be executed as follows::
+The Python rocRAND module can be installed using ``pip``:
 
-    cd rocrand/python/rocrand
-    python tests/rocrand_test.py
+.. code-block:: shell
+
+   cd rocrand/python/rocrand
+   pip install .
+
+The tests can be executed as follows:
+
+.. code-block:: shell
+
+   cd rocrand/python/rocrand
+   python tests/rocrand_test.py
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -5,11 +5,20 @@ subtrees:
   - caption: Install
     entries:
     - file: install/installing
+      title: Installation guide
+
   - caption: Conceptual
     entries:
     - file: conceptual/programmers-guide
+      title: Programming guide
     - file: conceptual/curand-compatibility
     - file: conceptual/dynamic_ordering_configuration
+
+  - caption: Examples
+    entries:
+    - url: https://github.com/ROCm/rocRAND/tree/develop/python/rocrand/examples
+      title: Examples
+
   - caption: API reference
     entries:
     - file: api-reference/data-type-support
@@ -17,6 +26,7 @@ subtrees:
     - file: api-reference/python-api
     - file: fortran-api-reference
     - file: doxygen/html/index
+
   - caption: About
     entries:
     - file: license


### PR DESCRIPTION
* First phase of rocRAND docs refresh

* Fix minor typo

* Add missing metadata

(cherry picked from commit 501f858d95a38ea6c2c40d1637663f214459a01b)

This PR merges part one of the documentation refresh changes from 7.0. There were no merge conflicts and no post-6.4 changes are included. There are some differences in the Doxygen files between branches, but based on my review, it does not seem to affect the display.